### PR TITLE
source : Undo freeing locally used git objects

### DIFF
--- a/src/luagit2/blame/lua_blame.c
+++ b/src/luagit2/blame/lua_blame.c
@@ -18,8 +18,6 @@ int lua_git_blame_buffer (lua_State *L) {
 	    "Error in generating blame buffer", NULL);
 	lua_blame->blame  = local_blame;
 
-	git_blame_free(local_blame);
-
 	return 1;
 }
 
@@ -39,8 +37,6 @@ int lua_git_blame_file (lua_State *L) {
 	check_error_long(git_blame_file(&local_blame, Repo->repo, path, NULL),
 	    "Error In generating blame for the given file", NULL);
 	lua_blame->blame  = local_blame;
-
-	git_blame_free(local_blame);
 
 	return 1;
 }

--- a/src/luagit2/blob/lua_blob.c
+++ b/src/luagit2/blob/lua_blob.c
@@ -54,7 +54,6 @@ int lua_git_blob_filtered_content (lua_State *L) {
         "Error getting filteres content of the blob", NULL);
 
     lua_out_buf->buf  = local_buf;
-    git_buf_free(local_buf);
     return 1;
 }
 

--- a/src/luagit2/branch/lua_branch.c
+++ b/src/luagit2/branch/lua_branch.c
@@ -19,7 +19,6 @@ int lua_git_branch_create (lua_State *L) {
 	    "Error creating new branch for target commit", NULL);
 	lua_ref->reference  = local_ref;
 
-	git_reference_free(local_ref);
 	return 1;
 }
 
@@ -42,7 +41,6 @@ int lua_git_branch_create_from_annotated (lua_State *L) {
 	        lua_annotated_commit->annotated_commit, force), "Error creating new branch for target annotated commit", NULL);
 	lua_ref->reference  = local_ref;
 
-	git_reference_free(local_ref);
 	return 1;
 }
 
@@ -103,7 +101,6 @@ int lua_git_branch_lookup (lua_State *L) {
 	    "Failed to find the branch in the given repository", NULL);
 	lua_ref->reference  = local_ref;
 
-	git_reference_free(local_ref);
 	return 1;
 }
 
@@ -125,7 +122,6 @@ int lua_git_branch_move (lua_State *L) {
 	    "Failed to rename/move the branch", NULL);
 	lua_ref->reference  = local_ref;
 
-	git_reference_free(local_ref);
 	return 1;
 }
 
@@ -154,7 +150,6 @@ int lua_git_branch_next (lua_State *L) {
 	    "Failed to get next branch name", NULL);
 	lua_ref->reference  = local_ref;
 
-	git_reference_free(local_ref);
 	return 1;
 }
 
@@ -182,6 +177,5 @@ int lua_git_branch_upstream (lua_State *L) {
 		"Error in getting branch upstream",NULL);
 	lua_ref->reference  = local_ref;
 
-	git_reference_free(local_ref);
 	return 1;
 }

--- a/src/luagit2/commit/lua_commit.c
+++ b/src/luagit2/commit/lua_commit.c
@@ -35,7 +35,6 @@ int lua_git_commit_committer (lua_State *L) {
 
 	git_signature *Signature = git_commit_committer(lua_commit->commit);
 	lua_sign->sign = Signature;
-	git_signature_free(Signature);
 
 	return 1;
 }
@@ -59,7 +58,7 @@ int lua_git_commit_extract_signature (lua_State *L) {
 	        Repo->repo, &(Commit_id->oid), field), "Error extracting signature from given commit id", NULL);
 
 	lua_signature_buf->buf  = local_sign_buf;
-	git_buf_free(local_sign_buf);
+
 	return 1;
 }
 
@@ -80,7 +79,7 @@ int lua_git_commit_header_field (lua_State *L) {
 	    "Error getting header field for the given commit", NULL);
 
 	lua_header_buf->buf  = local_out_buf;
-	git_buf_free(local_out_buf);
+
 	return 1;
 }
 
@@ -101,7 +100,7 @@ int lua_git_commit_lookup (lua_State *L) {
 	    "Failed to look up the commit in the given repo", NULL);
 
 	lua_Commit->commit  = local_commit;
-	git_commit_free(local_commit);
+
 	return 1;
 }
 
@@ -123,7 +122,7 @@ int lua_git_commit_lookup_prefix (lua_State *L) {
 	    "Failed to look up th commit in given repo using length of prefix", NULL);
 
 	lua_Commit->commit  = local_commit;
-	git_commit_free(local_commit);
+
 	return 1;
 }
 
@@ -168,7 +167,7 @@ int lua_git_commit_nth_gen_ancestor (lua_State *L) {
 	    "Failed to get the nth generation ancestor for the given commit", NULL);
 
 	lua_ancesstor_commit->commit  = local_commit;
-	git_commit_free(local_commit);
+
 	return 1;
 }
 
@@ -189,7 +188,7 @@ int lua_git_commit_parent (lua_State *L) {
 	    "Failed to get the parent commit for the given commit", NULL);
 
 	lua_Commit->commit  = local_commit;
-	git_commit_free(local_commit);
+
 	return 1;
 }
 
@@ -261,7 +260,7 @@ int lua_git_commit_tree (lua_State *L) {
 	    "Failed to get the tree for given commit", NULL);
 
 	lua_tree->tree  = local_tree_obj;
-	git_tree_free(local_tree_obj);
+
 	return 1;
 }
 

--- a/src/luagit2/common/lua_common.c
+++ b/src/luagit2/common/lua_common.c
@@ -33,8 +33,6 @@ void check_error_long(int error, const char *message, const char *extra) {
 		printf( "%s [%d]%s%s\n",
 		    message, error, lg2spacer, lg2msg);
 
-	printf("%s\n",  "Hello");
-
 	exit(1);
 }
 

--- a/src/luagit2/config/lua_config.c
+++ b/src/luagit2/config/lua_config.c
@@ -41,7 +41,6 @@ int lua_git_config_find_global (lua_State *L) {
 	check_error_long(git_config_find_global(&local_buf),
 	    "Unable to find global config ", NULL);
 	lua_buf->buf  = &local_buf;
-	git_buf_free(&local_buf);
 	return 1;
 }
 
@@ -60,7 +59,7 @@ int lua_git_config_find_programdata (lua_State *L) {
 	check_error_long(git_config_find_programdata(&local_buf),
 	    "Unable to find locate the path to the configuration file in ProgramData", NULL);
 	lua_buf->buf  = &local_buf;
-	git_buf_free(&local_buf);
+
 
 	return 1;
 }
@@ -80,7 +79,7 @@ int lua_git_config_find_system (lua_State *L) {
 	check_error_long(git_config_find_system(&local_buf),
 	    "Unable to locate the path to the system configuration file", NULL);
 	lua_buf->buf  = &local_buf;
-	git_buf_free(&local_buf);
+
 
 	return 1;
 }
@@ -100,7 +99,7 @@ int lua_git_config_find_xdg (lua_State *L) {
 	check_error_long(git_config_find_xdg(&local_buf),
 	    "Unable to Locate the path to the global xdg compatible configuration file", NULL);
 	lua_buf->buf  = &local_buf;
-	git_buf_free(&local_buf);
+
 
 	return 1;
 }
@@ -164,7 +163,7 @@ int lua_git_config_get_path (lua_State *L) {
 	check_error_long(git_config_get_path(&local_buf, parent_cfg->cfg, name),
 	    "Unable to get path for the config file", NULL);
 	lua_buf->buf  = &local_buf;
-	git_buf_free(&local_buf);
+
 
 	return 1;
 }
@@ -200,7 +199,6 @@ int lua_git_config_get_string_buf (lua_State *L) {
 	check_error_long(git_config_get_string_buf(&local_buf, parent_cfg->cfg, name),
 	    "Unable to get string buffer from the config", NULL);
 	lua_buf->buf  = &local_buf;
-	git_buf_free(&local_buf);
 
 	return 1;
 }
@@ -219,7 +217,7 @@ int lua_git_config_open_default (lua_State *L) {
 	check_error_long(git_config_open_default(&local_config),
 	    "Unable to open default config", NULL);
 	lua_cfg->cfg  = local_config;
-	git_config_free(local_config);
+
 	return 1;
 }
 
@@ -240,7 +238,7 @@ int lua_git_config_open_global (lua_State *L) {
 	check_error_long(git_config_open_global(&local_config, parent_cfg->cfg),
 	    "Unable to open global configuration", NULL);
 	lua_cfg->cfg  = local_config;
-	git_config_free(local_config);
+
 	return 1;
 }
 
@@ -262,7 +260,7 @@ int lua_git_config_open_level (lua_State *L) {
 	check_error_long(git_config_open_level(&local_config, parent_cfg->cfg, Level->level),
 	    "Unable to open specified configuration", NULL);
 	lua_cfg->cfg  = local_config;
-	git_config_free(local_config);
+
 	return 1;
 }
 
@@ -282,7 +280,7 @@ int lua_git_config_open_ondisk (lua_State *L) {
 	check_error_long(git_config_open_ondisk(&local_config, path),
 	    "Unable to open cifiguration file from disk", NULL);
 	lua_cfg->cfg  = local_config;
-	git_config_free(local_config);
+
 	return 1;
 }
 
@@ -331,7 +329,6 @@ int lua_git_config_parse_path (lua_State *L) {
 	check_error_long(git_config_parse_path(&local_buf, path_value),
 	    "Error parsing string as path value", NULL);
 	lua_buf->buf  = &local_buf;
-	git_buf_free(&local_buf);
 
 	return 1;
 }
@@ -424,7 +421,7 @@ int lua_git_config_snapshot (lua_State *L) {
 	check_error_long(git_config_snapshot(&local_config, parent_cfg->cfg),
 	    "Error getting config snapshot", NULL);
 	lua_cfg->cfg  = local_config;
-	git_config_free(local_config);
+
 	return 1;
 }
 

--- a/src/luagit2/cred/lua_cred.c
+++ b/src/luagit2/cred/lua_cred.c
@@ -15,7 +15,6 @@ int lua_git_cred_default_new (lua_State *L) {
 	    "Error creating a default luagit2_cred object", NULL);
 
 	cred_obj->git_cred_object  = out;
-	git_cred_free(out);
 	return 1;
 
 }
@@ -36,7 +35,6 @@ int lua_git_cred_ssh_key_from_agent (lua_State *L) {
 	    "Error creating SSH key credential from agent name", NULL);
 
 	cred_obj->git_cred_object  = out;
-	git_cred_free(out);
 	return 1;
 
 }
@@ -60,7 +58,6 @@ int lua_git_cred_ssh_key_memory_new (lua_State *L) {
 	    "Error creating in memory SSH key credentials from given details", NULL);
 
 	cred_obj->git_cred_object  = out;
-	git_cred_free(out);
 	return 1;
 
 }
@@ -84,7 +81,6 @@ int lua_git_cred_ssh_key_new (lua_State *L) {
 	    "Error creating SSH key credentials from given details", NULL);
 
 	cred_obj->git_cred_object  = out;
-	git_cred_free(out);
 	return 1;
 
 }
@@ -105,7 +101,6 @@ int lua_git_cred_username_new (lua_State *L) {
 	    "Error generating credentials from given user name", NULL);
 
 	cred_obj->git_cred_object  = out;
-	git_cred_free(out);
 	return 1;
 
 }
@@ -127,7 +122,6 @@ int lua_git_cred_userpass_plaintext_new (lua_State *L) {
 	    "Error generating credentials from given username and password ", NULL);
 
 	cred_obj->git_cred_object  = out;
-	git_cred_free(out);
 	return 1;
 
 }

--- a/src/luagit2/index/lua_index.c
+++ b/src/luagit2/index/lua_index.c
@@ -181,7 +181,6 @@ int lua_git_index_open(lua_State *L) {
 	check_error_long(git_index_open(&local_index, path),
 	    "Unable to create git object of index type from file at given path", NULL);
 	lua_index->index = local_index;
-	git_index_free(local_index);
 	return 1;
 }
 

--- a/src/luagit2/object/lua_object.c
+++ b/src/luagit2/object/lua_object.c
@@ -46,7 +46,6 @@ int lua_git_object_lookup(lua_State *L) {
 	check_error_long(git_object_lookup(&local_obj, Repository->repo, &(object_id->oid), Type->otype)
 	    , "Error looking up the object in given repo", NULL);
 	lua_object->object = local_obj;
-	git_object_free(local_obj);
 
 	return 1;
 }
@@ -67,7 +66,6 @@ int lua_git_object_lookup_bypath(lua_State *L) {
 	check_error_long(git_object_lookup_bypath(&local_obj, treeish->object, path, Type->otype)
 	    , "Error looking up the object in given repo by its path", NULL);
 	lua_object->object = local_obj;
-	git_object_free(local_obj);
 
 	return 1;
 }
@@ -89,7 +87,6 @@ int lua_git_object_lookup_prefix(lua_State *L) {
 	check_error_long(git_object_lookup_prefix(&local_obj, Repository->repo, &(object_id->oid), length,
 	        Type->otype), "Error looking up the object in given repo for given length prefix", NULL);
 	lua_object->object = local_obj;
-	git_object_free(local_obj);
 
 	return 1;
 }
@@ -124,7 +121,6 @@ int lua_git_object_short_id (lua_State *L) {
 	    "Unable to get abbreviated OID", NULL);
 
 	lua_out_buf->buf  = local_buf;
-	git_buf_free(local_buf);
 	return 1;
 }
 

--- a/src/luagit2/reference/lua_reference.c
+++ b/src/luagit2/reference/lua_reference.c
@@ -19,7 +19,6 @@ int lua_git_reference_create (lua_State *L) {
 	check_error_long(git_reference_create(&local_ref, lua_repo->repo, name,
 	        &(lua_oid->oid), force, log_message), "Error creating reference with details provided", NULL);
 	lua_ref->reference  = local_ref;
-	git_reference_free(local_ref);
 	return 1;
 }
 
@@ -43,7 +42,7 @@ int lua_git_reference_create_matching (lua_State *L) {
 	check_error_long(git_reference_create_matching(&local_ref, lua_repo->repo, name, &(lua_oid->oid),
 	        force, &(current_oid->oid), log_message), "Error creating matching reference", NULL);
 	lua_ref->reference  = local_ref;
-	git_reference_free(local_ref);
+
 	return 1;
 }
 
@@ -62,7 +61,7 @@ int lua_git_reference_dup (lua_State *L) {
 	check_error_long(git_reference_dup(&local_ref, lua_ref_source->reference),
 	    "Error creating duplicate reference", NULL);
 	lua_ref->reference  = local_ref;
-	git_reference_free(local_ref);
+
 	return 1;
 }
 
@@ -82,7 +81,7 @@ int lua_git_reference_dwim (lua_State *L) {
 	check_error_long(git_reference_dwim(&local_ref, lua_repo->repo, shorthand),
 	    "Unable to Lookup a reference by DWIMing its short name", NULL);
 	lua_ref->reference  = local_ref;
-	git_reference_free(local_ref);
+
 	return 1;
 }
 
@@ -160,7 +159,7 @@ int lua_git_reference_iterator_glob_new (lua_State *L) {
 	check_error_long(git_reference_iterator_glob_new(&local_ref_iterator, lua_repo->repo, glob),
 	    "Error creating a global reference iterator ", NULL);
 	lua_ref_iterator->iterator  = local_ref_iterator;
-	git_reference_iterator_free(local_ref_iterator);
+
 	return 1;
 }
 
@@ -179,7 +178,7 @@ int lua_git_reference_iterator_new (lua_State *L) {
 	check_error_long(git_reference_iterator_new(&local_ref_iterator, lua_repo->repo),
 	    "Error creating new reference iterator", NULL);
 	lua_ref_iterator->iterator  = local_ref_iterator;
-	git_reference_iterator_free(local_ref_iterator);
+
 	return 1;
 }
 
@@ -215,7 +214,7 @@ int lua_git_reference_lookup (lua_State *L) {
 	check_error_long(git_reference_lookup(&local_ref, lua_repo->repo, name),
 	    "Error looking up the reference in the given repo", NULL);
 	lua_ref->reference  = local_ref;
-	git_reference_free(local_ref);
+
 	return 1;
 }
 
@@ -260,7 +259,7 @@ int lua_git_reference_next (lua_State *L) {
 	check_error_long(git_reference_next(&local_ref, lua_ref_iterator->iterator),
 	    "Error in finding next reference object", NULL);
 	lua_ref->reference  = local_ref;
-	git_reference_free(local_ref);
+
 	return 1;
 }
 
@@ -302,7 +301,7 @@ int lua_git_reference_peel (lua_State *L) {
 	check_error_long(git_reference_peel(&local_git_obj, lua_ref->reference, type->otype),
 	    "Unable to do a reference peel", NULL);
 	lua_git_obj->object = local_git_obj;
-	git_object_free(local_git_obj);
+
 	return 1;
 }
 
@@ -333,7 +332,7 @@ int lua_git_reference_rename (lua_State *L) {
 	check_error_long(git_reference_rename(&local_ref, lua_ref_old->reference, new_name, force, log_message),
 	    "Unable to rename the reference", NULL);
 	lua_ref->reference  = local_ref;
-	git_reference_free(local_ref);
+
 	return 1;
 }
 
@@ -352,7 +351,7 @@ int lua_git_reference_resolve (lua_State *L) {
 	check_error_long(git_reference_resolve(&local_ref, lua_ref_old->reference),
 	    "Unable to resolve old reference to a new one", NULL);
 	lua_ref->reference  = local_ref;
-	git_reference_free(local_ref);
+
 	return 1;
 }
 
@@ -373,7 +372,7 @@ int lua_git_reference_set_target (lua_State *L) {
 	check_error_long(git_reference_set_target(&local_ref, lua_ref_old->reference, &(lua_oid->oid), log_message),
 	    "Unable to set target reference", NULL);
 	lua_ref->reference  = local_ref;
-	git_reference_free(local_ref);
+
 	return 1;
 }
 
@@ -396,7 +395,7 @@ int lua_git_reference_symbolic_create (lua_State *L) {
 	check_error_long(git_reference_symbolic_create(&local_ref, lua_repo->repo, name, target, force, log_message),
 	    "Unable to create symbolic reference", NULL);
 	lua_ref->reference  = local_ref;
-	git_reference_free(local_ref);
+
 	return 1;
 }
 
@@ -420,7 +419,7 @@ int lua_git_reference_symbolic_create_matching (lua_State *L) {
 	check_error_long(git_reference_symbolic_create_matching(&local_ref, lua_repo->repo, name, target,
 	        force, current_value, log_message), "Unable to create matching symbolic reference", NULL);
 	lua_ref->reference  = local_ref;
-	git_reference_free(local_ref);
+
 	return 1;
 }
 
@@ -441,7 +440,7 @@ int lua_git_reference_symbolic_set_target (lua_State *L) {
 	check_error_long(git_reference_symbolic_set_target(&local_ref, lua_ref_old->reference, target, log_message),
 		"Unable to set a symbolic target", NULL);
 	lua_ref->reference  = local_ref;
-	git_reference_free(local_ref);
+
 	return 1;
 }
 

--- a/src/luagit2/repository/lua_repository.c
+++ b/src/luagit2/repository/lua_repository.c
@@ -22,7 +22,6 @@ int lua_git_repository_config (lua_State *L) {
 	git_repository_config(&local_config, lua_repo->repo);
 	lua_cfg->cfg  = local_config;
 
-	git_config_free(local_config);
 	return 1;
 }
 
@@ -40,7 +39,7 @@ int lua_git_repository_config_snapshot (lua_State *L) {
 	git_config *local_config;
 	git_repository_config_snapshot(&local_config, lua_repo->repo);
 	lua_cfg->cfg  = local_config;
-	git_config_free(local_config);
+
 	return 1;
 }
 
@@ -71,7 +70,7 @@ int lua_git_repository_head (lua_State *L) {
 	git_reference *local_ref;
 	git_repository_head(&local_ref, lua_repo->repo);
 	lua_ref->reference  = local_ref;
-	git_reference_free(local_ref);
+
 
 	return 1;
 }
@@ -98,7 +97,6 @@ int lua_git_repository_head_for_worktree (lua_State *L) {
 	git_reference *local_ref;
 	git_repository_head_for_worktree(&local_ref, lua_repo->repo, name);
 	lua_ref->reference  = local_ref;
-	git_reference_free(local_ref);
 
 	return 1;
 }
@@ -140,7 +138,6 @@ int lua_git_repository_index(lua_State *L) {
 	git_repository_index(&local_index, lua_repo->repo);
 
 	lua_index->index  = local_index;
-	git_index_free(local_index);
 
 	return 1;
 }
@@ -166,7 +163,7 @@ int lua_git_repository_init (lua_State *L) {
 	git_repository_init(&local_repository, path, is_bare);
 
 	lua_repo->repo = local_repository ;
-	git_repository_free(local_repository);
+
 	return 1;
 }
 
@@ -212,7 +209,6 @@ int lua_git_repository_message (lua_State *L) {
 	git_buf local_buf = {0};
 	git_repository_message(&local_buf, lua_repo->repo);
 	lua_buf->buf  = &local_buf;
-	git_buf_free(&local_buf);
 
 	return 1;
 }
@@ -238,7 +234,7 @@ int lua_git_repository_odb (lua_State *L) {
 	git_odb *local_odb;
 	git_repository_odb(&local_odb, lua_repo->repo);
 	lua_odb->odb  = local_odb;
-	git_odb_free(local_odb);
+
 	return 1;
 }
 
@@ -261,7 +257,7 @@ int lua_git_repository_open(lua_State *L) {
 	git_repository_open(&Repository, path);
 
 	lua_repo->repo = Repository ;
-	git_repository_free(Repository);
+
 	return 1;
 }
 
@@ -284,7 +280,7 @@ int lua_git_repository_open_bare(lua_State *L) {
 	git_repository_open_bare(&Repository, bare_path);
 
 	lua_repo->repo = Repository ;
-	git_repository_free(Repository);
+
 	return 1;
 }
 
@@ -302,7 +298,7 @@ int lua_git_repository_open_from_worktree (lua_State *L) {
 	git_repository_open_from_worktree(&Repository, lua_worktree->worktree);
 
 	lua_repo->repo = Repository ;
-	git_repository_free(Repository);
+
 	return 1;
 }
 
@@ -327,7 +323,7 @@ int lua_git_repository_refdb (lua_State *L) {
 	git_refdb *local_refdb;
 	git_repository_refdb(&local_refdb, lua_repo->repo);
 	lua_refdb->refdb  = local_refdb;
-	git_refdb_free(local_refdb);
+
 	return 1;
 }
 

--- a/src/luagit2/signature/lua_signature.c
+++ b/src/luagit2/signature/lua_signature.c
@@ -16,7 +16,6 @@ int lua_git_signature_default (lua_State *L) {
 	    "Error getting default signature details for the given repository", NULL);
 
 	lua_sign->sign  = local_sign_obj;
-	git_signature_free(local_sign_obj);
 	return 1;
 }
 
@@ -36,7 +35,7 @@ int lua_git_signature_dup (lua_State *L) {
 	    "Error generating duplicate signature", NULL);
 
 	lua_sign->sign  = local_sign_obj;
-	git_signature_free(local_sign_obj);
+
 	return 1;
 }
 
@@ -56,7 +55,6 @@ int lua_git_signature_from_buffer (lua_State *L) {
 	    "Error generating signature from buffer string", NULL);
 
 	lua_sign->sign  = local_sign_obj;
-	git_signature_free(local_sign_obj);
 
 	return 1;
 }
@@ -78,7 +76,7 @@ int lua_git_signature_now (lua_State *L) {
 		"Error generating signature from given user and email details", NULL);
 
 	lua_sign->sign  = local_sign_obj;
-	git_signature_free(local_sign_obj);
+
 	return 1;
 }
 

--- a/src/luagit2/tag/lua_tag.c
+++ b/src/luagit2/tag/lua_tag.c
@@ -152,7 +152,6 @@ int lua_git_tag_lookup (lua_State *L) {
 	check_error_long(git_tag_lookup(&local_tag, lua_repo->repo, &(lua_oid->oid)),
 	    "Error looking up the tag in the given repo", NULL);
 	lua_tag->tag  = local_tag;
-	git_tag_free(local_tag);
 	return 1;
 }
 
@@ -173,7 +172,7 @@ int lua_git_tag_lookup_prefix (lua_State *L) {
 	check_error_long(git_tag_lookup_prefix(&local_tag, lua_repo->repo, &(lua_oid->oid), length),
 	    "Error looking up the tag in the given repo using prefix", NULL);
 	lua_tag->tag  = local_tag;
-	git_tag_free(local_tag);
+
 	return 1;
 }
 
@@ -239,7 +238,7 @@ int lua_git_tag_target (lua_State *L) {
 	check_error_long(git_tag_target(&local_git_obj, lua_tag->tag),
 	    "Unable to find target object for the given tag", NULL);
 	lua_git_obj->object = local_git_obj;
-	git_object_free(local_git_obj);
+
 	return 1;
 }
 

--- a/src/luagit2/tree/lua_tree.c
+++ b/src/luagit2/tree/lua_tree.c
@@ -68,7 +68,6 @@ int lua_git_tree_entry_bypath(lua_State *L) {
 	    "Error in getting tree entry by given file path", NULL);
 	lua_tree_entry->tree_entry = local_tree_entry;
 
-	git_tree_entry_free(local_tree_entry);
 	return 1;
 }
 
@@ -148,7 +147,7 @@ int lua_git_tree_entry_to_object (lua_State *L) {
 	    "Error getting the object pointed by given tree entry", NULL);
 
 	lua_obj->object  = local_obj;
-	git_object_free(local_obj);
+
 	return 1;
 }
 
@@ -205,7 +204,7 @@ int lua_git_tree_lookup (lua_State *L) {
 	    "Error looking up the tree id in the given repository", NULL);
 
 	lua_tree->tree  = local_tree_obj;
-	git_tree_free(local_tree_obj);
+
 	return 1;
 }
 
@@ -227,7 +226,7 @@ int lua_git_tree_lookup_prefix (lua_State *L) {
 	    "Error looking up the tree id in the given repository using its prefix", NULL);
 
 	lua_tree->tree  = local_tree_obj;
-	git_tree_free(local_tree_obj);
+
 	return 1;
 }
 


### PR DESCRIPTION
Freeing the locally used git objects was causing the pointers of luagit2_* type objects used for lua-C api to point to NULL hence causing Errors.