### PR TITLE
Refactor oid tree tag signature modules (source + test)

### DIFF
--- a/src/luagit2/index/lua_index_help.c
+++ b/src/luagit2/index/lua_index_help.c
@@ -5,7 +5,7 @@ int lua_git_index_entry_get_path(lua_State *L) {
 	if ((Index_entry->index_entry) != NULL) {
 		lua_pushstring(L, (Index_entry->index_entry)->path);
 	} else {
-		lua_pushstring(L, null_err);
+		luaL_error(L, null_err);
 	}
 	return 1;
 }
@@ -15,7 +15,7 @@ int lua_git_index_entry_get_filemode(lua_State *L) {
 	if ((Index_entry->index_entry) != NULL) {
 		lua_pushinteger(L, (int)(Index_entry->index_entry)->mode);
 	} else {
-		lua_pushstring(L, null_err);
+		luaL_error(L, null_err);
 	}
 	return 1;
 }
@@ -25,7 +25,7 @@ int lua_git_index_entry_get_filesize(lua_State *L) {
 	if ((Index_entry->index_entry) != NULL) {
 		lua_pushinteger(L, (int)(Index_entry->index_entry)->file_size);
 	} else {
-		lua_pushstring(L, null_err);
+		luaL_error(L, null_err);
 	}
 	return 1;
 }
@@ -35,7 +35,7 @@ int lua_git_index_entry_get_stage(lua_State *L) {
 	if ((Index_entry->index_entry) != NULL) {
 		lua_pushinteger(L, git_index_entry_stage(Index_entry->index_entry));
 	} else {
-		lua_pushstring(L, null_err);
+		luaL_error(L, null_err);
 	}
 	return 1;
 }
@@ -48,7 +48,7 @@ int lua_git_index_entry_get_oid_str(lua_State *L) {
 		git_oid_fmt(out, &(Index_entry->index_entry)->id);
 		lua_pushstring(L, out);
 	} else {
-		lua_pushstring(L, null_err);
+		luaL_error(L, null_err);
 	}
 	return 1;
 }
@@ -59,7 +59,7 @@ int lua_git_index_entry_get_dev_inode(lua_State *L) {
 		lua_pushinteger(L, (Index_entry->index_entry)->dev);
 		lua_pushinteger(L, (Index_entry->index_entry)->ino);
 	} else {
-		lua_pushstring(L, null_err);
+		luaL_error(L, null_err);
 	}
 	return 2;
 
@@ -71,7 +71,7 @@ int lua_git_index_entry_get_UID_GID(lua_State *L) {
 		lua_pushinteger(L, (Index_entry->index_entry)->uid);
 		lua_pushinteger(L, (Index_entry->index_entry)->gid);
 	} else {
-		lua_pushstring(L, null_err);
+		luaL_error(L, null_err);
 	}
 	return 2;
 }

--- a/src/luagit2/oid/lua_oid.c
+++ b/src/luagit2/oid/lua_oid.c
@@ -1,6 +1,11 @@
 #include "lua_oid.h"
 
 int lua_git_oid_fromstr (lua_State *L) {
+
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : oid_string");
+	}
+
 	luagit2_oid *obj_id;
 	const char *string_value = luaL_checkstring(L, 1);
 
@@ -18,6 +23,11 @@ int lua_git_oid_fromstr (lua_State *L) {
 }
 
 int lua_git_oid_fromstrn (lua_State *L) {
+
+	if (lua_gettop(L) != 2) {
+		return luaL_error(L, "expecting exactly 2 arguments : oid_string, length");
+	}
+
 	luagit2_oid *obj_id;
 	const char *string_value = luaL_checkstring(L, 1);
 	size_t length = luaL_checkinteger(L, 2);
@@ -36,11 +46,16 @@ int lua_git_oid_fromstrn (lua_State *L) {
 }
 
 int lua_git_oid_cmp (lua_State *L) {
+
+	if (lua_gettop(L) != 2) {
+		return luaL_error(L, "expecting exactly 2 arguments : luagit2_oid, luagit2_oid");
+	}
+
 	const luagit2_oid *oid_A;
 	const luagit2_oid *oid_B;
 
-	oid_A = (luagit2_oid *)lua_touserdata(L, 1);
-	oid_B = (luagit2_oid *)lua_touserdata(L, 2);
+	oid_A = (luagit2_oid *)luaL_checkudata(L, 1, "luagit2_oid");
+	oid_B = (luagit2_oid *)luaL_checkudata(L, 2, "luagit2_oid");
 	int result = git_oid_cmp(&(oid_A->oid), &(oid_B->oid));
 
 	lua_pushinteger(L, result);
@@ -48,11 +63,16 @@ int lua_git_oid_cmp (lua_State *L) {
 }
 
 int lua_git_oid_ncmp (lua_State *L) {
+
+	if (lua_gettop(L) != 3) {
+		return luaL_error(L, "expecting exactly 3 arguments : luagit2_oid, luagit2_oid, length");
+	}
+
 	const luagit2_oid *oid_A;
 	const luagit2_oid *oid_B;
 
-	oid_A = (luagit2_oid *)lua_touserdata(L, 1);
-	oid_B = (luagit2_oid *)lua_touserdata(L, 2);
+	oid_A = (luagit2_oid *)luaL_checkudata(L, 1, "luagit2_oid");
+	oid_B = (luagit2_oid *)luaL_checkudata(L, 2, "luagit2_oid");
 	size_t length = luaL_checkinteger(L, 3);
 	int result = git_oid_ncmp(&(oid_A->oid), &(oid_B->oid), length);
 
@@ -61,9 +81,14 @@ int lua_git_oid_ncmp (lua_State *L) {
 }
 
 int lua_git_oid_fmt (lua_State *L) {
+
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_oid");
+	}
+
 	const luagit2_oid *oid_A;
 
-	oid_A = (luagit2_oid *)lua_touserdata(L, 1);
+	oid_A = (luagit2_oid *)luaL_checkudata(L, 1, "luagit2_oid");
 
 	char result_str[GIT_OID_HEXSZ + 1];
 	result_str[GIT_OID_HEXSZ] = '\0';
@@ -74,9 +99,14 @@ int lua_git_oid_fmt (lua_State *L) {
 }
 
 int lua_git_oid_nfmt (lua_State *L) {
+
+	if (lua_gettop(L) != 2) {
+		return luaL_error(L, "expecting exactly 2 arguments : luagit2_oid, length");
+	}
+
 	const luagit2_oid *oid_A;
 
-	oid_A = (luagit2_oid *)lua_touserdata(L, 1);
+	oid_A = (luagit2_oid *)luaL_checkudata(L, 1, "luagit2_oid");
 	size_t length = luaL_checkinteger(L, 2);
 	char result_str[GIT_OID_HEXSZ + 1];
 	result_str[GIT_OID_HEXSZ] = '\0';
@@ -87,9 +117,14 @@ int lua_git_oid_nfmt (lua_State *L) {
 }
 
 int lua_git_oid_pathfmt (lua_State *L) {
+
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_oid");
+	}
+
 	const luagit2_oid *oid_A;
 
-	oid_A = (luagit2_oid *)lua_touserdata(L, 1);
+	oid_A = (luagit2_oid *)luaL_checkudata(L, 1, "luagit2_oid");
 
 	char result_str[GIT_OID_HEXSZ + 2];
 	result_str[GIT_OID_HEXSZ + 1] = '\0';
@@ -100,19 +135,29 @@ int lua_git_oid_pathfmt (lua_State *L) {
 }
 
 int lua_git_oid_iszero (lua_State *L) {
+
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_oid");
+	}
+
 	const luagit2_oid *oid_A;
 
-	oid_A = (luagit2_oid *)lua_touserdata(L, 1);
+	oid_A = (luagit2_oid *)luaL_checkudata(L, 1, "luagit2_oid");
 	int result = git_oid_iszero(&(oid_A->oid));
 
-	lua_pushinteger(L, result);
+	lua_pushboolean(L, result);
 	return 1;
 }
 
 int lua_git_oid_strcmp (lua_State *L) {
+
+	if (lua_gettop(L) != 2) {
+		return luaL_error(L, "expecting exactly 2 arguments : luagit2_oid, string");
+	}
+
 	const luagit2_oid *oid_A;
 
-	oid_A = (luagit2_oid *)lua_touserdata(L, 1);
+	oid_A = (luagit2_oid *)luaL_checkudata(L, 1, "luagit2_oid");
 	const char *string_to_compare = luaL_checkstring(L, 2);
 	int result = git_oid_strcmp(&(oid_A->oid), string_to_compare);
 
@@ -122,9 +167,14 @@ int lua_git_oid_strcmp (lua_State *L) {
 }
 
 int lua_git_oid_tostr (lua_State *L) {
+
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_oid");
+	}
+
 	const luagit2_oid *oid_A;
 
-	oid_A = (luagit2_oid *)lua_touserdata(L, 1);
+	oid_A = (luagit2_oid *)luaL_checkudata(L, 1, "luagit2_oid");
 	char buffer[1024] = {0};
 	char *string_value = git_oid_tostr(buffer, sizeof(buffer), &(oid_A->oid));
 	lua_pushstring(L, string_value);
@@ -133,9 +183,14 @@ int lua_git_oid_tostr (lua_State *L) {
 }
 
 int lua_git_oid_tostr_s (lua_State *L) {
+
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_oid");
+	}
+
 	const luagit2_oid *oid_A;
 
-	oid_A = (luagit2_oid *)lua_touserdata(L, 1);
+	oid_A = (luagit2_oid *)luaL_checkudata(L, 1, "luagit2_oid");
 	const char *string_value = git_oid_tostr_s(&(oid_A->oid));
 
 	lua_pushstring(L, string_value);

--- a/src/luagit2/signature/lua_signature.c
+++ b/src/luagit2/signature/lua_signature.c
@@ -1,8 +1,13 @@
 #include "lua_signature.h"
 
 int lua_git_signature_default (lua_State *L) {
+
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_repository");
+	}
+
 	luagit2_signature *lua_sign;
-	const luagit2_repository *Repo = (luagit2_repository *)lua_touserdata(L, 1);
+	const luagit2_repository *Repo = (luagit2_repository *)luaL_checkudata(L, 1, "luagit2_repository");
 
 	lua_sign = (luagit2_signature *)lua_newuserdata(L, sizeof(*lua_sign));
 	lua_sign->sign  = NULL;
@@ -20,8 +25,13 @@ int lua_git_signature_default (lua_State *L) {
 }
 
 int lua_git_signature_dup (lua_State *L) {
+
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_signature");
+	}
+
 	luagit2_signature *lua_sign;
-	const luagit2_signature *source_sign = (luagit2_signature *)lua_touserdata(L, 1);
+	const luagit2_signature *source_sign = (luagit2_signature *)luaL_checkudata(L, 1, "luagit2_signature");
 
 	lua_sign = (luagit2_signature *)lua_newuserdata(L, sizeof(*lua_sign));
 	lua_sign->sign  = NULL;
@@ -40,6 +50,11 @@ int lua_git_signature_dup (lua_State *L) {
 }
 
 int lua_git_signature_from_buffer (lua_State *L) {
+
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : string");
+	}
+
 	luagit2_signature *lua_sign;
 	const char *buf_string = luaL_checkstring(L, 1);
 
@@ -60,6 +75,11 @@ int lua_git_signature_from_buffer (lua_State *L) {
 }
 
 int lua_git_signature_now (lua_State *L) {
+
+	if (lua_gettop(L) != 2) {
+		return luaL_error(L, "expecting exactly 2 argument : name_string,email_string");
+	}
+
 	luagit2_signature *lua_sign;
 	const char *name = luaL_checkstring(L, 1);
 	const char *email = luaL_checkstring(L, 2);
@@ -73,7 +93,7 @@ int lua_git_signature_now (lua_State *L) {
 
 	git_signature *local_sign_obj;
 	check_error_long(git_signature_now(&local_sign_obj, name, email),
-		"Error generating signature from given user and email details", NULL);
+	    "Error generating signature from given user and email details", NULL);
 
 	lua_sign->sign  = local_sign_obj;
 
@@ -81,7 +101,12 @@ int lua_git_signature_now (lua_State *L) {
 }
 
 int lua_git_signature_free (lua_State *L) {
-	const luagit2_signature *lua_sign = (luagit2_signature *)lua_touserdata(L, 1);
+
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_signature");
+	}
+
+	const luagit2_signature *lua_sign = (luagit2_signature *)luaL_checkudata(L, 1, "luagit2_signature");
 	git_signature_free(lua_sign->sign);
 	return 1;
 }

--- a/src/luagit2/signature/lua_signature_help.c
+++ b/src/luagit2/signature/lua_signature_help.c
@@ -1,12 +1,12 @@
 #include "lua_signature_help.h"
 
-static void print_signature( const git_signature *sig)
-{
+static void print_signature( const git_signature *sig) {
 	char sign;
 	int offset, hours, minutes;
 
-	if (!sig)
+	if (!sig) {
 		return;
+	}
 
 	offset = sig->when.offset;
 	if (offset < 0) {
@@ -20,27 +20,41 @@ static void print_signature( const git_signature *sig)
 	minutes = offset % 60;
 
 	printf("%s <%s> %ld %c%02d%02d\n",
-		   sig->name, sig->email, (long)sig->when.time,
-		   sign, hours, minutes);
+	    sig->name, sig->email, (long)sig->when.time,
+	    sign, hours, minutes);
 }
 
 int lua_get_signature_details (lua_State *L) {
-	const luagit2_signature *signature_data = (luagit2_signature *)lua_touserdata(L, 1);
-	int which_value = luaL_checkinteger(L,2);
 
-	switch(which_value)
-	{
-		case 1:  lua_pushstring(L,signature_data->sign->name);
-		    	break;
-		case 2: lua_pushstring(L,signature_data->sign->email);
-		    	break;
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_signature");
 	}
 
-    return 1;
+	const luagit2_signature *signature_data = (luagit2_signature *)luaL_checkudata(L, 1, "luagit2_signature");
+
+	if (signature_data->sign != NULL) {
+		lua_pushstring(L, signature_data->sign->name);
+		lua_pushstring(L, signature_data->sign->email);
+		return 2;
+	} else {
+		return luaL_error(L, null_err);
+	}
+
 }
 
 int lua_print_complete_signature_details (lua_State *L) {
-	const luagit2_signature *signature_data = (luagit2_signature *)lua_touserdata(L, 1);
-	print_signature(signature_data->sign);
-    return 1;
+
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_signature");
+	}
+
+	const luagit2_signature *signature_data = (luagit2_signature *)luaL_checkudata(L, 1, "luagit2_signature");
+
+	if (signature_data->sign != NULL) {
+		print_signature(signature_data->sign);
+		return 1;
+	} else {
+		return luaL_error(L, null_err);
+	}
+
 }

--- a/src/luagit2/tag/lua_tag.c
+++ b/src/luagit2/tag/lua_tag.c
@@ -1,14 +1,19 @@
 #include "lua_tag.h"
 
 int lua_git_tag_annotation_create(lua_State *L) {
-	luagit2_oid *obj_id;
-	const luagit2_repository *Repository = (luagit2_repository *)lua_touserdata(L, 1);
+
+	if (lua_gettop(L) != 5) {
+		return luaL_error(L, "expecting exactly 5 arguments : luagit2_repository,string_name,\
+		        luagit2_object, luagit2_signature, string, message");
+	}
+
+	const luagit2_repository *Repository = (luagit2_repository *)luaL_checkudata(L, 1, "luagit2_repository");
 	const char *tag_name = luaL_checkstring(L, 2);
-	const luagit2_object *target_obj = (luagit2_object *)lua_touserdata(L, 3);
-	const luagit2_signature *tagger = (luagit2_signature *)lua_touserdata(L, 4);
+	const luagit2_object *target_obj = (luagit2_object *)luaL_checkudata(L, 3, "luagit2_object");
+	const luagit2_signature *tagger = (luagit2_signature *)luaL_checkudata(L, 4, "luagit2_signature");
 	const char *tag_message = luaL_checkstring(L, 5);
 
-	obj_id = (luagit2_oid *)lua_newuserdata(L, sizeof(*obj_id));
+	luagit2_oid *obj_id = (luagit2_oid *)lua_newuserdata(L, sizeof(*obj_id));
 
 	luaL_newmetatable(L, "luagit2_oid");
 	lua_setmetatable(L, -2);
@@ -20,15 +25,20 @@ int lua_git_tag_annotation_create(lua_State *L) {
 }
 
 int lua_git_tag_create(lua_State *L) {
-	luagit2_oid *obj_id;
-	const luagit2_repository *Repository = (luagit2_repository *)lua_touserdata(L, 1);
+
+	if (lua_gettop(L) != 6) {
+		return luaL_error(L, "expecting exactly 6 arguments : luagit2_repository,string_name,\
+		        luagit2_object, luagit2_signature, string, message, int_force");
+	}
+
+	const luagit2_repository *Repository = (luagit2_repository *)luaL_checkudata(L, 1, "luagit2_repository");
 	const char *tag_name = luaL_checkstring(L, 2);
-	const luagit2_object *target_obj = (luagit2_object *)lua_touserdata(L, 3);
-	const luagit2_signature *tagger = (luagit2_signature *)lua_touserdata(L, 4);
+	const luagit2_object *target_obj = (luagit2_object *)luaL_checkudata(L, 3, "luagit2_object");
+	const luagit2_signature *tagger = (luagit2_signature *)luaL_checkudata(L, 4, "luagit2_signature");
 	const char *tag_message = luaL_checkstring(L, 5);
 	const int force = luaL_checkinteger(L, 6);
 
-	obj_id = (luagit2_oid *)lua_newuserdata(L, sizeof(*obj_id));
+	luagit2_oid *obj_id = (luagit2_oid *)lua_newuserdata(L, sizeof(*obj_id));
 
 	luaL_newmetatable(L, "luagit2_oid");
 	lua_setmetatable(L, -2);
@@ -40,12 +50,16 @@ int lua_git_tag_create(lua_State *L) {
 }
 
 int lua_git_tag_create_frombuffer(lua_State *L) {
-	luagit2_oid *obj_id;
-	const luagit2_repository *Repository = (luagit2_repository *)lua_touserdata(L, 1);
+
+	if (lua_gettop(L) != 3) {
+		return luaL_error(L, "expecting exactly 3 arguments : luagit2_repository,string_name,int_force");
+	}
+
+	const luagit2_repository *Repository = (luagit2_repository *)luaL_checkudata(L, 1, "luagit2_repository");
 	const char *buffer = luaL_checkstring(L, 2);
 	const int force = luaL_checkinteger(L, 3);
 
-	obj_id = (luagit2_oid *)lua_newuserdata(L, sizeof(*obj_id));
+	luagit2_oid *obj_id = (luagit2_oid *)lua_newuserdata(L, sizeof(*obj_id));
 
 	luaL_newmetatable(L, "luagit2_oid");
 	lua_setmetatable(L, -2);
@@ -57,13 +71,17 @@ int lua_git_tag_create_frombuffer(lua_State *L) {
 }
 
 int lua_git_tag_create_lightweight(lua_State *L) {
-	luagit2_oid *obj_id;
-	const luagit2_repository *Repository = (luagit2_repository *)lua_touserdata(L, 1);
+
+	if (lua_gettop(L) != 4) {
+		return luaL_error(L, "expecting exactly 4 arguments : luagit2_repository,string_name,luagit2_object,int_force");
+	}
+
+	const luagit2_repository *Repository = (luagit2_repository *)luaL_checkudata(L, 1, "luagit2_repository");
 	const char *tag_name = luaL_checkstring(L, 2);
-	const luagit2_object *target_obj = (luagit2_object *)lua_touserdata(L, 3);
+	const luagit2_object *target_obj = (luagit2_object *)luaL_checkudata(L, 3, "luagit2_object");
 	const int force = luaL_checkinteger(L, 4);
 
-	obj_id = (luagit2_oid *)lua_newuserdata(L, sizeof(*obj_id));
+	luagit2_oid *obj_id = (luagit2_oid *)lua_newuserdata(L, sizeof(*obj_id));
 
 	luaL_newmetatable(L, "luagit2_oid");
 	lua_setmetatable(L, -2);
@@ -75,7 +93,12 @@ int lua_git_tag_create_lightweight(lua_State *L) {
 }
 
 int lua_git_tag_delete(lua_State *L) {
-	const luagit2_repository *Repository = (luagit2_repository *)lua_touserdata(L, 1);
+
+	if (lua_gettop(L) != 2) {
+		return luaL_error(L, "expecting exactly 2 arguments : luagit2_repository,string_name");
+	}
+
+	const luagit2_repository *Repository = (luagit2_repository *)luaL_checkudata(L, 1, "luagit2_repository");
 	const char *tag_name = luaL_checkstring(L, 2);
 
 	check_error_long(git_tag_delete( Repository->repo, tag_name),
@@ -85,17 +108,26 @@ int lua_git_tag_delete(lua_State *L) {
 }
 
 int lua_git_tag_free(lua_State *L) {
-	const luagit2_tag *Tag = (luagit2_tag *)lua_touserdata(L, 1);
+
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_tag");
+	}
+
+	const luagit2_tag *Tag = (luagit2_tag *)luaL_checkudata(L, 1, "luagit2_tag");
 	git_tag_free( Tag->tag);
 
 	return 1;
 }
 
 int lua_git_tag_id(lua_State *L) {
-	luagit2_oid *obj_id;
-	const luagit2_tag *Tag = (luagit2_tag *)lua_touserdata(L, 1);
 
-	obj_id = (luagit2_oid *)lua_newuserdata(L, sizeof(*obj_id));
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_tag");
+	}
+
+	const luagit2_tag *Tag = (luagit2_tag *)luaL_checkudata(L, 1, "luagit2_tag");
+
+	luagit2_oid *obj_id = (luagit2_oid *)lua_newuserdata(L, sizeof(*obj_id));
 
 	luaL_newmetatable(L, "luagit2_oid");
 	lua_setmetatable(L, -2);
@@ -106,10 +138,14 @@ int lua_git_tag_id(lua_State *L) {
 }
 
 int lua_git_tag_list (lua_State *L) {
-	luagit2_strarray *lua_array;
-	const luagit2_repository *lua_repo = (luagit2_repository *)lua_touserdata(L, 1);
 
-	lua_array = (luagit2_strarray *)lua_newuserdata(L, sizeof(*lua_array));
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_repository");
+	}
+
+	const luagit2_repository *lua_repo = (luagit2_repository *)luaL_checkudata(L, 1, "luagit2_repository");
+
+	luagit2_strarray *lua_array = (luagit2_strarray *)lua_newuserdata(L, sizeof(*lua_array));
 	luaL_newmetatable(L, "luagit2_strarray");
 	lua_setmetatable(L, -2);
 
@@ -121,11 +157,15 @@ int lua_git_tag_list (lua_State *L) {
 }
 
 int lua_git_tag_list_match (lua_State *L) {
-	luagit2_strarray *lua_array;
-	const luagit2_repository *lua_repo = (luagit2_repository *)lua_touserdata(L, 1);
+
+	if (lua_gettop(L) != 2) {
+		return luaL_error(L, "expecting exactly 2 arguments : luagit2_repository,string_pattern");
+	}
+
+	const luagit2_repository *lua_repo = (luagit2_repository *)luaL_checkudata(L, 1, "luagit2_repository");
 	const char *pattern = luaL_checkstring(L, 2);
 
-	lua_array = (luagit2_strarray *)lua_newuserdata(L, sizeof(*lua_array));
+	luagit2_strarray *lua_array = (luagit2_strarray *)lua_newuserdata(L, sizeof(*lua_array));
 	luaL_newmetatable(L, "luagit2_strarray");
 	lua_setmetatable(L, -2);
 
@@ -137,11 +177,15 @@ int lua_git_tag_list_match (lua_State *L) {
 }
 
 int lua_git_tag_lookup (lua_State *L) {
-	luagit2_tag *lua_tag;
-	const luagit2_repository *lua_repo = (luagit2_repository *)lua_touserdata(L, 1);
-	const luagit2_oid *lua_oid = (luagit2_oid *)lua_touserdata(L, 2);
 
-	lua_tag = (luagit2_tag *)lua_newuserdata(L, sizeof(*lua_tag));
+	if (lua_gettop(L) != 2) {
+		return luaL_error(L, "expecting exactly 2 arguments : luagit2_repository,luagit2_oid");
+	}
+
+	const luagit2_repository *lua_repo = (luagit2_repository *)luaL_checkudata(L, 1, "luagit2_repository");
+	const luagit2_oid *lua_oid = (luagit2_oid *)luaL_checkudata(L, 2, "luagit2_oid");
+
+	luagit2_tag *lua_tag = (luagit2_tag *)lua_newuserdata(L, sizeof(*lua_tag));
 	lua_tag->tag  = NULL;
 
 	luaL_newmetatable(L, "luagit2_tag");
@@ -156,12 +200,16 @@ int lua_git_tag_lookup (lua_State *L) {
 }
 
 int lua_git_tag_lookup_prefix (lua_State *L) {
-	luagit2_tag *lua_tag;
-	const luagit2_repository *lua_repo = (luagit2_repository *)lua_touserdata(L, 1);
-	const luagit2_oid *lua_oid = (luagit2_oid *)lua_touserdata(L, 2);
+
+	if (lua_gettop(L) != 3) {
+		return luaL_error(L, "expecting exactly 3 arguments : luagit2_repository,luagit2_oid,int_length");
+	}
+
+	const luagit2_repository *lua_repo = (luagit2_repository *)luaL_checkudata(L, 1, "luagit2_repository");
+	const luagit2_oid *lua_oid = (luagit2_oid *)luaL_checkudata(L, 2, "luagit2_oid");
 	const size_t length = luaL_checkinteger(L, 3);
 
-	lua_tag = (luagit2_tag *)lua_newuserdata(L, sizeof(*lua_tag));
+	luagit2_tag *lua_tag = (luagit2_tag *)lua_newuserdata(L, sizeof(*lua_tag));
 	lua_tag->tag  = NULL;
 
 	luaL_newmetatable(L, "luagit2_tag");
@@ -177,7 +225,12 @@ int lua_git_tag_lookup_prefix (lua_State *L) {
 }
 
 int lua_git_tag_message(lua_State *L) {
-	const luagit2_tag *Tag = (luagit2_tag *)lua_touserdata(L, 1);
+
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_tag");
+	}
+
+	const luagit2_tag *Tag = (luagit2_tag *)luaL_checkudata(L, 1, "luagit2_tag");
 	const char *tag_message = git_tag_message( Tag->tag);
 
 	lua_pushstring(L, tag_message);
@@ -186,7 +239,12 @@ int lua_git_tag_message(lua_State *L) {
 }
 
 int lua_git_tag_name(lua_State *L) {
-	const luagit2_tag *Tag = (luagit2_tag *)lua_touserdata(L, 1);
+
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_tag");
+	}
+
+	const luagit2_tag *Tag = (luagit2_tag *)luaL_checkudata(L, 1, "luagit2_tag");
 	const char *tag_name = git_tag_name( Tag->tag);
 
 	lua_pushstring(L, tag_name);
@@ -195,10 +253,14 @@ int lua_git_tag_name(lua_State *L) {
 }
 
 int lua_git_tag_owner(lua_State *L) {
-	luagit2_repository *lua_repo;
-	const luagit2_tag *lua_tag = (luagit2_tag *)lua_touserdata(L, 1);
 
-	lua_repo = (luagit2_repository *)lua_newuserdata(L, sizeof(*lua_repo));
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_tag");
+	}
+
+	const luagit2_tag *lua_tag = (luagit2_tag *)luaL_checkudata(L, 1, "luagit2_tag");
+
+	luagit2_repository *lua_repo = (luagit2_repository *)lua_newuserdata(L, sizeof(*lua_repo));
 	lua_repo->repo  = NULL;
 
 	luaL_newmetatable(L, "luagit2_repository");
@@ -210,7 +272,12 @@ int lua_git_tag_owner(lua_State *L) {
 }
 
 int lua_git_tag_tagger (lua_State *L) {
-	const luagit2_tag *lua_tag = (luagit2_tag *)lua_touserdata(L, 1);
+
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_tag");
+	}
+
+	const luagit2_tag *lua_tag = (luagit2_tag *)luaL_checkudata(L, 1, "luagit2_tag");
 
 	luagit2_signature *lua_sign;
 	lua_sign = (luagit2_signature *)lua_newuserdata(L, sizeof(*lua_sign));
@@ -225,10 +292,13 @@ int lua_git_tag_tagger (lua_State *L) {
 }
 
 int lua_git_tag_target (lua_State *L) {
-	luagit2_object *lua_git_obj;
-	const luagit2_tag *lua_tag = (luagit2_tag *)lua_touserdata(L, 1);
 
-	lua_git_obj = (luagit2_object *)lua_newuserdata(L, sizeof(*lua_git_obj));
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_tag");
+	}
+
+	const luagit2_tag *lua_tag = (luagit2_tag *)luaL_checkudata(L, 1, "luagit2_tag");
+	luagit2_object *lua_git_obj = (luagit2_object *)lua_newuserdata(L, sizeof(*lua_git_obj));
 	lua_git_obj->object  = NULL;
 
 	luaL_newmetatable(L, "luagit2_object");
@@ -243,10 +313,13 @@ int lua_git_tag_target (lua_State *L) {
 }
 
 int lua_git_tag_target_id(lua_State *L) {
-	luagit2_oid *obj_id;
-	const luagit2_tag *Tag = (luagit2_tag *)lua_touserdata(L, 1);
 
-	obj_id = (luagit2_oid *)lua_newuserdata(L, sizeof(*obj_id));
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_tag");
+	}
+
+	const luagit2_tag *Tag = (luagit2_tag *)luaL_checkudata(L, 1, "luagit2_tag");
+	luagit2_oid *obj_id = (luagit2_oid *)lua_newuserdata(L, sizeof(*obj_id));
 
 	luaL_newmetatable(L, "luagit2_oid");
 	lua_setmetatable(L, -2);
@@ -257,10 +330,14 @@ int lua_git_tag_target_id(lua_State *L) {
 }
 
 int lua_git_tag_target_type (lua_State *L) {
-	luagit2_otype *target_type;
-	const luagit2_tag *lua_tag = (luagit2_tag *)lua_touserdata(L, 1);
 
-	target_type = (luagit2_otype *)lua_newuserdata(L, sizeof(*target_type));
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_tag");
+	}
+
+	const luagit2_tag *lua_tag = (luagit2_tag *)luaL_checkudata(L, 1, "luagit2_tag");
+
+	luagit2_otype *target_type = (luagit2_otype *)lua_newuserdata(L, sizeof(*target_type));
 
 	luaL_newmetatable(L, "luagit2_otype");
 	lua_setmetatable(L, -2);

--- a/src/luagit2/tree/lua_tree.c
+++ b/src/luagit2/tree/lua_tree.c
@@ -1,8 +1,13 @@
 #include "lua_tree.h"
 
 int lua_git_tree_entry_byid(lua_State *L) {
-	const luagit2_tree *Tree = (luagit2_tree *)lua_touserdata(L, 1);
-	const luagit2_oid *obj_id = (luagit2_oid *)lua_touserdata(L, 2);
+
+	if (lua_gettop(L) != 2) {
+		return luaL_error(L, "expecting exactly 2 argument : luagit2_tree,luagit2_oid");
+	}
+
+	const luagit2_tree *Tree = (luagit2_tree *)luaL_checkudata(L, 1, "luagit2_tree");
+	const luagit2_oid *obj_id = (luagit2_oid *)luaL_checkudata(L, 2, "luagit2_oid");
 
 	luagit2_tree_entry *lua_tree_entry;
 
@@ -18,7 +23,12 @@ int lua_git_tree_entry_byid(lua_State *L) {
 }
 
 int lua_git_tree_entry_byindex(lua_State *L) {
-	const luagit2_tree *Tree = (luagit2_tree *)lua_touserdata(L, 1);
+
+	if (lua_gettop(L) != 2) {
+		return luaL_error(L, "expecting exactly 2 argument : luagit2_tree,index");
+	}
+
+	const luagit2_tree *Tree = (luagit2_tree *)luaL_checkudata(L, 1,"luagit2_tree");
 	size_t index = luaL_checkinteger(L, 2);
 
 	luagit2_tree_entry *lua_tree_entry;
@@ -35,7 +45,12 @@ int lua_git_tree_entry_byindex(lua_State *L) {
 }
 
 int lua_git_tree_entry_byname(lua_State *L) {
-	const luagit2_tree *Tree = (luagit2_tree *)lua_touserdata(L, 1);
+
+	if (lua_gettop(L) != 2) {
+		return luaL_error(L, "expecting exactly 2 argument : luagit2_tree,filename");
+	}
+
+	const luagit2_tree *Tree = (luagit2_tree *)luaL_checkudata(L, 1,"luagit2_tree");
 	const char *filename = luaL_checkstring(L, 2);
 
 	luagit2_tree_entry *lua_tree_entry;
@@ -52,7 +67,12 @@ int lua_git_tree_entry_byname(lua_State *L) {
 }
 
 int lua_git_tree_entry_bypath(lua_State *L) {
-	const luagit2_tree *Tree = (luagit2_tree *)lua_touserdata(L, 1);
+
+	if (lua_gettop(L) != 2) {
+		return luaL_error(L, "expecting exactly 2 argument : luagit2_tree,path");
+	}
+
+	const luagit2_tree *Tree = (luagit2_tree *)luaL_checkudata(L, 1,"luagit2_tree");
 	const char *path = luaL_checkstring(L, 2);
 
 	luagit2_tree_entry *lua_tree_entry;
@@ -73,8 +93,13 @@ int lua_git_tree_entry_bypath(lua_State *L) {
 
 
 int lua_git_tree_entry_cmp(lua_State *L) {
-	const luagit2_tree_entry *Tree_entry1 = (luagit2_tree_entry *)lua_touserdata(L, 1);
-	const luagit2_tree_entry *Tree_entry2 = (luagit2_tree_entry *)lua_touserdata(L, 2);
+
+	if (lua_gettop(L) != 2) {
+		return luaL_error(L, "expecting exactly 2 argument : luagit2_tree,luagit2_tree");
+	}
+
+	const luagit2_tree_entry *Tree_entry1 = (luagit2_tree_entry *)luaL_checkudata(L, 1,"luagit2_tree_entry");
+	const luagit2_tree_entry *Tree_entry2 = (luagit2_tree_entry *)luaL_checkudata(L, 2,"luagit2_tree_entry");
 
 	int result = git_tree_entry_cmp(Tree_entry1->tree_entry, Tree_entry2->tree_entry);
 	lua_pushinteger(L, result);
@@ -82,8 +107,13 @@ int lua_git_tree_entry_cmp(lua_State *L) {
 }
 
 int lua_git_tree_entry_filemode(lua_State *L) {
+
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_tree_entry");
+	}
+
 	luagit2_filemode *File_Mode;
-	const luagit2_tree_entry *Tree_entry = (luagit2_tree_entry *)lua_touserdata(L, 1);
+	const luagit2_tree_entry *Tree_entry = (luagit2_tree_entry *)luaL_checkudata(L, 1,"luagit2_tree_entry");
 
 	File_Mode = (luagit2_filemode *)lua_newuserdata(L, sizeof(*File_Mode));
 
@@ -95,8 +125,13 @@ int lua_git_tree_entry_filemode(lua_State *L) {
 }
 
 int lua_git_tree_entry_filemode_raw(lua_State *L) {
+
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_tree_entry");
+	}
+
 	luagit2_filemode *File_Mode;
-	const luagit2_tree_entry *Tree_entry = (luagit2_tree_entry *)lua_touserdata(L, 1);
+	const luagit2_tree_entry *Tree_entry = (luagit2_tree_entry *)luaL_checkudata(L, 1,"luagit2_tree_entry");
 
 	File_Mode = (luagit2_filemode *)lua_newuserdata(L, sizeof(*File_Mode));
 
@@ -108,8 +143,13 @@ int lua_git_tree_entry_filemode_raw(lua_State *L) {
 }
 
 int lua_git_tree_entry_id(lua_State *L) {
+
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_tree_entry");
+	}
+
 	luagit2_oid *obj_id;
-	const luagit2_tree_entry *Tree_entry = (luagit2_tree_entry *)lua_touserdata(L, 1);
+	const luagit2_tree_entry *Tree_entry = (luagit2_tree_entry *)luaL_checkudata(L, 1,"luagit2_tree_entry");
 
 	obj_id = (luagit2_oid *)lua_newuserdata(L, sizeof(*obj_id));
 
@@ -123,7 +163,12 @@ int lua_git_tree_entry_id(lua_State *L) {
 }
 
 int lua_git_tree_entry_name (lua_State *L) {
-	const luagit2_tree_entry *Tree_entry = (luagit2_tree_entry *)lua_touserdata(L, 1);
+
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_tree_entry");
+	}
+
+	const luagit2_tree_entry *Tree_entry = (luagit2_tree_entry *)luaL_checkudata(L, 1,"luagit2_tree_entry");
 
 	const char *entry_name = git_tree_entry_name(Tree_entry->tree_entry);
 	lua_pushstring(L, entry_name);
@@ -131,8 +176,13 @@ int lua_git_tree_entry_name (lua_State *L) {
 }
 
 int lua_git_tree_entry_to_object (lua_State *L) {
-	luagit2_repository *Repo = (luagit2_repository *)lua_touserdata(L, 1);
-	const luagit2_tree_entry *Tree_entry = (luagit2_tree_entry *)lua_touserdata(L, 2);
+
+	if (lua_gettop(L) != 2) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_repository,luagit2_tree_entry");
+	}
+
+	luagit2_repository *Repo = (luagit2_repository *)luaL_checkudata(L, 1,"luagit2_repository");
+	const luagit2_tree_entry *Tree_entry = (luagit2_tree_entry *)luaL_checkudata(L, 2,"luagit2_tree_entry");
 
 	luagit2_object *lua_obj;
 
@@ -152,8 +202,13 @@ int lua_git_tree_entry_to_object (lua_State *L) {
 }
 
 int lua_git_tree_entry_type(lua_State *L) {
+
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_tree_entry");
+	}
+
 	luagit2_otype *obj_type;
-	const luagit2_tree_entry *Tree_entry = (luagit2_tree_entry *)lua_touserdata(L, 1);
+	const luagit2_tree_entry *Tree_entry = (luagit2_tree_entry *)luaL_checkudata(L, 1,"luagit2_tree_entry");
 
 	obj_type = (luagit2_otype *)lua_newuserdata(L, sizeof(*obj_type));
 
@@ -166,7 +221,12 @@ int lua_git_tree_entry_type(lua_State *L) {
 }
 
 int lua_git_tree_entrycount(lua_State *L) {
-	const luagit2_tree *Tree = (luagit2_tree *)lua_touserdata(L, 1);
+
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_tree");
+	}
+
+	const luagit2_tree *Tree = (luagit2_tree *)luaL_checkudata(L, 1,"luagit2_tree");
 
 	size_t result = git_tree_entrycount(Tree->tree);
 	lua_pushinteger(L, result);
@@ -174,8 +234,13 @@ int lua_git_tree_entrycount(lua_State *L) {
 }
 
 int lua_git_tree_id(lua_State *L) {
+
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_tree");
+	}
+
 	luagit2_oid *obj_id;
-	const luagit2_tree *Tree = (luagit2_tree *)lua_touserdata(L, 1);
+	const luagit2_tree *Tree = (luagit2_tree *)luaL_checkudata(L, 1,"luagit2_tree");
 
 	obj_id = (luagit2_oid *)lua_newuserdata(L, sizeof(*obj_id));
 
@@ -188,8 +253,13 @@ int lua_git_tree_id(lua_State *L) {
 }
 
 int lua_git_tree_lookup (lua_State *L) {
-	luagit2_repository *Repo = (luagit2_repository *)lua_touserdata(L, 1);
-	const luagit2_oid *Tree_id = (luagit2_oid *)lua_touserdata(L, 2);
+
+	if (lua_gettop(L) != 2) {
+		return luaL_error(L, "expecting exactly 2 arguments : luagit2_repository, luagit2_oid");
+	}
+
+	luagit2_repository *Repo = (luagit2_repository *)luaL_checkudata(L, 1,"luagit2_repository");
+	const luagit2_oid *Tree_id = (luagit2_oid *)luaL_checkudata(L, 2,"luagit2_oid");
 
 	luagit2_tree *lua_tree;
 
@@ -209,8 +279,13 @@ int lua_git_tree_lookup (lua_State *L) {
 }
 
 int lua_git_tree_lookup_prefix (lua_State *L) {
-	luagit2_repository *Repo = (luagit2_repository *)lua_touserdata(L, 1);
-	const luagit2_oid *Tree_id = (luagit2_oid *)lua_touserdata(L, 2);
+
+	if (lua_gettop(L) != 3) {
+		return luaL_error(L, "expecting exactly 2 arguments : luagit2_repository,luagit2_oid,length");
+	}
+
+	luagit2_repository *Repo = (luagit2_repository *)luaL_checkudata(L, 1,"luagit2_repository");
+	const luagit2_oid *Tree_id = (luagit2_oid *)luaL_checkudata(L, 2,"luagit2_oid");
 	size_t length = luaL_checkinteger(L, 3);
 
 	luagit2_tree *lua_tree;
@@ -231,8 +306,13 @@ int lua_git_tree_lookup_prefix (lua_State *L) {
 }
 
 int lua_git_tree_owner(lua_State *L) {
+
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_tree");
+	}
+
 	luagit2_repository *lua_repo;
-	const luagit2_tree *Tree = (luagit2_tree *)lua_touserdata(L, 1);
+	const luagit2_tree *Tree = (luagit2_tree *)luaL_checkudata(L, 1,"luagit2_tree");
 
 	lua_repo = (luagit2_repository *)lua_newuserdata(L, sizeof(*lua_repo));
 	lua_repo->repo  = NULL;
@@ -246,13 +326,23 @@ int lua_git_tree_owner(lua_State *L) {
 }
 
 int lua_git_tree_entry_free (lua_State *L) {
-	const luagit2_tree_entry *Tree_entry = (luagit2_tree_entry *)lua_touserdata(L, 1);
+
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_tree_entry");
+	}
+
+	const luagit2_tree_entry *Tree_entry = (luagit2_tree_entry *)luaL_checkudata(L, 1,"luagit2_tree_entry");
 	git_tree_entry_free( Tree_entry->tree_entry);
 	return 1;
 }
 
 int lua_git_tree_free (lua_State *L) {
-	const luagit2_tree *Tree = (luagit2_tree *)lua_touserdata(L, 1);
+
+	if (lua_gettop(L) != 1) {
+		return luaL_error(L, "expecting exactly 1 argument : luagit2_tree");
+	}
+
+	const luagit2_tree *Tree = (luagit2_tree *)luaL_checkudata(L, 1,"luagit2_tree");
 	git_tree_free( Tree->tree);
 	return 1;
 }

--- a/tests/oid/test_oid_spec.lua
+++ b/tests/oid/test_oid_spec.lua
@@ -1,150 +1,152 @@
 -- Tests for luagit2's oid module functions
 
 describe("oid methods test", function()
-
-	local lib = require("luagit2")
-	local Obj_Id
-	local Obj_Id_String = "1385f264afb75a56a5bec74243be9b367ba4ca08" -- Object ID of Fixtures/testrepo2/README
-	local Obj_Id_semi_zero_A, Obj_Id_semi_zero_B
-	local Obj_Id_semi_zero_string_A = "1385f264afb75a56a5b000000000000000000000"
-	local Obj_Id_semi_zero_string_B = "0000000000000006a5bec74243be9b367ba4ca08"
-	local Obj_Id_2
-	local Obj_Id_String_2 = "fa49b077972391ad58037050f2a75f74e3671e92" -- Object ID of Fixtures/testrepo2/new.txt
-	local Zero_Obj_Id
-	local Zero_Obj_Id_String = "0000000000000000000000000000000000000000"
-	local Extra_Object -- A Extra variable to demonstrate `Dis-Similar` Object Creation
-
+    
+    local luagit2 = require("luagit2")
+    local obj_id
+    local obj_id_string = "1385f264afb75a56a5bec74243be9b367ba4ca08" -- Object ID of Fixtures/new_test_repo/README
+    local obj_id_semi_zero_a, obj_id_semi_zero_b
+    local obj_id_semi_zero_string_a = "1385f264afb75a56a5b000000000000000000000"
+    local obj_id_semi_zero_string_b = "0000000000000006a5bec74243be9b367ba4ca08"
+    local obj_id_2
+    local obj_id_string_2 = "fa49b077972391ad58037050f2a75f74e3671e92" -- Object ID of Fixtures/new_test_repo/new.txt
+    local zero_obj_id
+    local zero_obj_id_string = "0000000000000000000000000000000000000000"
+    
     setup(function()
-		lib.luagit2_init()
+        -- initialize libgit2's global state and threading
+        luagit2.init()
     end)
-
+    
     teardown(function()
-		lib.luagit2_shutdown()
+        -- close threading and global state.
+        luagit2.shutdown()
     end)
-
+    
     before_each(function()
-		Obj_Id = lib.luagit2_oid_fromstr(Obj_Id_String)
-		Obj_Id_semi_zero_A = lib.luagit2_oid_fromstr(Obj_Id_semi_zero_string_A)
-		Obj_Id_semi_zero_B = lib.luagit2_oid_fromstr(Obj_Id_semi_zero_string_B)
-		Obj_Id_2 = lib.luagit2_oid_fromstr(Obj_Id_String_2)
-		Zero_Obj_Id = lib.luagit2_oid_fromstr(Zero_Obj_Id_String)
-	end)
-
+        -- setup different variables
+        obj_id = luagit2.oid_fromstr(obj_id_string)
+        obj_id_semi_zero_a = luagit2.oid_fromstr(obj_id_semi_zero_string_a)
+        obj_id_semi_zero_b = luagit2.oid_fromstr(obj_id_semi_zero_string_b)
+        obj_id_2 = luagit2.oid_fromstr(obj_id_string_2)
+        zero_obj_id = luagit2.oid_fromstr(zero_obj_id_string)
+    end)
+    
     it("Checks data type and metatable name ", function()
-		-- Checks if Passed Data is not nil
-		assert.is.not_nil(Obj_Id)
-    	assert.is.not_nil(Obj_Id_semi_zero_A)
-    	assert.is.not_nil(Obj_Id_semi_zero_B)
-    	assert.is.not_nil(Obj_Id_2)
-    	assert.is.not_nil(Zero_Obj_Id)
-
-    	-- Checks the Passed Data type
-    	assert.are.same("userdata",type(Obj_Id))
-    	assert.are.same("userdata",type(Obj_Id_semi_zero_A))
-    	assert.are.same("userdata",type(Obj_Id_semi_zero_B))
-    	assert.are.same("userdata",type(Obj_Id_2))
-    	assert.are.same("userdata",type(Zero_Obj_Id))
-
-    	-- Checks the metatable name to be luagit2_oid 
-    	-- luagit2's Oid struct.(See src/lua_objects.h)
-    	assert.are.same("luagit2_oid",lib.get_userdata_name(Obj_Id))
-    	assert.are.same("luagit2_oid",lib.get_userdata_name(Obj_Id_semi_zero_A))
-    	assert.are.same("luagit2_oid",lib.get_userdata_name(Obj_Id_semi_zero_B))
-    	assert.are.same("luagit2_oid",lib.get_userdata_name(Obj_Id_2))
-    	assert.are.same("luagit2_oid",lib.get_userdata_name(Zero_Obj_Id))
+        -- checks if passed data is not nil
+        assert.is.not_nil(obj_id)
+        assert.is.not_nil(obj_id_semi_zero_a)
+        assert.is.not_nil(obj_id_semi_zero_b)
+        assert.is.not_nil(obj_id_2)
+        assert.is.not_nil(zero_obj_id)
+        
+        -- checks the passed data type
+        assert.are.same("userdata", type(obj_id))
+        assert.are.same("userdata", type(obj_id_semi_zero_a))
+        assert.are.same("userdata", type(obj_id_semi_zero_b))
+        assert.are.same("userdata", type(obj_id_2))
+        assert.are.same("userdata", type(zero_obj_id))
+        
+        -- checks the metatable name to be luagit2_oid
+        -- luagit2's oid struct.(see src/lua_objects.h)
+        assert.are.same("luagit2_oid", luagit2.get_userdata_name(obj_id))
+        assert.are.same("luagit2_oid", luagit2.get_userdata_name(obj_id_semi_zero_a))
+        assert.are.same("luagit2_oid", luagit2.get_userdata_name(obj_id_semi_zero_b))
+        assert.are.same("luagit2_oid", luagit2.get_userdata_name(obj_id_2))
+        assert.are.same("luagit2_oid", luagit2.get_userdata_name(zero_obj_id))
     end)
-
+    
     it("Tests Obj_Id to its equivalent String", function()
-    	-- Check the string value of Object Ids if they are equal 
-    	-- to that used for initializing or not.
-
-    	assert.are.same(Obj_Id_String, lib.luagit2_oid_tostr(Obj_Id))
-    	assert.are.same(Obj_Id_String_2, lib.luagit2_oid_tostr(Obj_Id_2))
-    	assert.are.same(Obj_Id_semi_zero_string_A, lib.luagit2_oid_tostr(Obj_Id_semi_zero_A))
-    	assert.are.same(Obj_Id_semi_zero_string_B, lib.luagit2_oid_tostr(Obj_Id_semi_zero_B))
-
-    	-- Reinitializing Obj_Id value using Obj_Id_String_2
-    	-- Tests setting oibject Id by string
-    	Obj_Id = lib.luagit2_oid_fromstr(Obj_Id_String_2)
-    	assert.are.not_same(Obj_Id_String, lib.luagit2_oid_tostr(Obj_Id))
-    	assert.are.same(Obj_Id_String_2, lib.luagit2_oid_tostr(Obj_Id))
+        -- Check the string value of Object Ids if they are equal
+        -- to that used for initializing or not.
+        
+        assert.are.same(obj_id_string, luagit2.oid_tostr(obj_id))
+        assert.are.same(obj_id_string_2, luagit2.oid_tostr(obj_id_2))
+        assert.are.same(obj_id_semi_zero_string_a, luagit2.oid_tostr(obj_id_semi_zero_a))
+        assert.are.same(obj_id_semi_zero_string_b, luagit2.oid_tostr(obj_id_semi_zero_b))
+        
+        -- reinitializing obj_id value using obj_id_string_2
+        -- tests setting oibject id by string
+        obj_id = luagit2.oid_fromstr(obj_id_string_2)
+        assert.are.not_same(obj_id_string, luagit2.oid_tostr(obj_id))
+        assert.are.same(obj_id_string_2, luagit2.oid_tostr(obj_id))
     end)
-
+    
     it("Tests Creating Dis-Similar Objects", function()
-    	-- This is very important to note
-    	-- That even if using Same string values,
-    	-- The Created Objects will differ on direct Comparison
-    	-- Though their Contained String Value will be same
-
-    	-- Setting another Alternate Object with Obj_Id_String,
-    	-- Same as that used for Obj_Id
-
-    	Extra_Object = lib.luagit2_oid_fromstr(Obj_Id_String)
-    	assert(not(Extra_Object == Obj_Id))
-
-    	-- Checking their contained string value
-    	assert.are.equal(lib.luagit2_oid_tostr(Obj_Id),lib.luagit2_oid_tostr(Extra_Object))
+        -- This is very important to note
+        -- That even if using Same string values,
+        -- The Created Objects will differ on direct Comparison
+        -- Though their Contained String Value will be same
+        
+        -- Setting another Alternate Object with Obj_Id_String,
+        -- Same as that used for Obj_Id
+        
+        local extra_object = luagit2.oid_fromstr(obj_id_string)
+        assert(not(extra_object == obj_id))
+        
+        -- checking their contained string value
+        assert.are.equal(luagit2.oid_tostr(obj_id), luagit2.oid_tostr(extra_object))
     end)
-
-    it(" Tests Comparison of two Object Ids",function()
-    	-- It returns Integer Value for comparing two luagit2_oid's (A,B)
-    	-- < 0 if A < B
-    	-- = 0 if A = B
-    	-- > 0 if A > B
-
-    	-- Object_Id is oid for README 
-    	-- Object_ID_2 is oid for new.txt
-    	-- Since README was created before new.txt, 
-    	-- The Oid of README will be less than that of new.txt
-    	assert((lib.luagit2_oid_cmp(Obj_Id,Obj_Id_2)) < 0)
-    	assert((lib.luagit2_oid_cmp(Obj_Id_2,Obj_Id)) > 0)
-
-    	assert((lib.luagit2_oid_cmp(Obj_Id,Obj_Id)) == 0)
+    
+    it(" Tests Comparison of two Object Ids", function()
+        -- It returns Integer Value for comparing two luagit2_oid's (A,B)
+        -- < 0 if A < B
+        -- = 0 if A = B
+        -- > 0 if A > B
+        
+        -- object_id is oid for README
+        -- object_id_2 is oid for new.txt
+        -- Since README was created before new.txt,
+        -- The Oid of README will be less than that of new.txt
+        assert((luagit2.oid_cmp(obj_id, obj_id_2)) < 0)
+        assert((luagit2.oid_cmp(obj_id_2, obj_id)) > 0)
+        
+        assert((luagit2.oid_cmp(obj_id, obj_id)) == 0)
     end)
-
-    it(" Tests Comparison of two Object Ids for a given length counted from left",function()
-    	-- Returns Zero in case of match
-    	assert(lib.luagit2_oid_ncmp(Obj_Id,Obj_Id_semi_zero_A,10) == 0)
-    	assert(lib.luagit2_oid_ncmp(Obj_Id,Obj_Id_semi_zero_B,10) ~= 0)
+    
+    it(" Tests Comparison of two Object Ids for a given length counted from left", function()
+        -- Returns Zero in case of match
+        assert(luagit2.oid_ncmp(obj_id, obj_id_semi_zero_a, 10) == 0)
+        assert(luagit2.oid_ncmp(obj_id, obj_id_semi_zero_b, 10) ~= 0)
     end)
-
+    
     it(" Tests oid_from_strn ", function()
-    	-- new oid created using first n length of string.
-    	Obj_Id = lib.luagit2_oid_fromstrn(Obj_Id_String,19)
-    	assert((lib.luagit2_oid_cmp(Obj_Id,Obj_Id_semi_zero_A)) == 0)
-    	assert.are.equal(lib.luagit2_oid_tostr(Obj_Id),Obj_Id_semi_zero_string_A)
+        -- new oid created using first n length of string.
+        obj_id = luagit2.oid_fromstrn(obj_id_string, 19)
+        assert((luagit2.oid_cmp(obj_id, obj_id_semi_zero_a)) == 0)
+        assert.are.equal(luagit2.oid_tostr(obj_id), obj_id_semi_zero_string_a)
     end)
-
+    
     it(" Tests Comparison of Object Id and equivalent String Values", function()
-    	-- Check for string values of different Object_Ids
-    	assert.are.equal(lib.luagit2_oid_tostr(Obj_Id),Obj_Id_String)
-    	assert.are.equal(lib.luagit2_oid_tostr(Obj_Id_2),Obj_Id_String_2)
-    	assert.are.equal(lib.luagit2_oid_tostr(Obj_Id_semi_zero_A),Obj_Id_semi_zero_string_A)
-    	assert.are.equal(lib.luagit2_oid_tostr(Obj_Id_semi_zero_B),Obj_Id_semi_zero_string_B)
-    	assert.are.equal(lib.luagit2_oid_tostr(Zero_Obj_Id),Zero_Obj_Id_String)
+        -- Check for string values of different Object_Ids
+        assert.are.equal(luagit2.oid_tostr(obj_id), obj_id_string)
+        assert.are.equal(luagit2.oid_tostr(obj_id_2), obj_id_string_2)
+        assert.are.equal(luagit2.oid_tostr(obj_id_semi_zero_a), obj_id_semi_zero_string_a)
+        assert.are.equal(luagit2.oid_tostr(obj_id_semi_zero_b), obj_id_semi_zero_string_b)
+        assert.are.equal(luagit2.oid_tostr(zero_obj_id), zero_obj_id_string)
     end)
-
+    
     it(" Tests whether the OBject Id contains all zeros", function()
-    	-- It Returns Integer value
-    	-- 1 if oid has all zeros
-    	-- 0 if oid does not have all zeros
-    	assert(lib.luagit2_oid_iszero(Obj_Id) == 0)
-    	assert(lib.luagit2_oid_iszero(Zero_Obj_Id) == 1)
+        -- It Returns Integer value
+        -- true if oid has all zeros
+        -- false if oid does not have all zeros
+        assert.is_false(luagit2.oid_iszero(obj_id))
+        assert.is_true(luagit2.oid_iszero(zero_obj_id))
     end)
-
+    
     it(" Tests Various Formatting methods available", function()
-    	-- format the oid for entire string value 
-    	assert.are.equal(lib.luagit2_oid_nfmt(Obj_Id,40),Obj_Id_String)
-
-    	-- format oid only for first 10 readable chars
-    	-- The value is non readable after 10 chars.
-    	assert(string.find(lib.luagit2_oid_nfmt(Obj_Id,10),"1385f264af"))
-
-    	-- Tests the path of object as in .git/objects/
-    	assert.are.equal(lib.luagit2_oid_pathfmt(Obj_Id),"13/85f264afb75a56a5bec74243be9b367ba4ca08")
-
-    	-- Format the Object Id to be complete human readable string.
-    	assert.are.equal(lib.luagit2_oid_fmt(Obj_Id),Obj_Id_String)
+        -- format the oid for entire string value
+        assert.are.equal(luagit2.oid_nfmt(obj_id, 40), obj_id_string)
+        
+        -- format oid only for first 10 readable chars
+        -- The value is non readable after 10 chars.
+        assert(string.find(luagit2.oid_nfmt(obj_id, 10), "1385f264af"))
+        
+        -- Tests the path of object as in .git/objects/
+        assert.are.equal(luagit2.oid_pathfmt(obj_id), "13/85f264afb75a56a5bec74243be9b367ba4ca08")
+        
+        -- Format the Object Id to be complete human readable string.
+        assert.are.equal(luagit2.oid_fmt(obj_id), obj_id_string)
     end)
-
+    
 end)

--- a/tests/signature/test_signature_spec.lua
+++ b/tests/signature/test_signature_spec.lua
@@ -3,31 +3,32 @@
 local fixer = require("Fixtures.fix_repo")
 
 describe(" Signature Methods Tests ", function()
-	local lib = require("luagit2")
-
-	setup(function()
-		lib.luagit2_init()
-	end)
-
-	before_each(function()
-		fixer.set_repo("new_test_repo")
-		repo = lib.luagit2_repository_open("Fixtures/WORKON_REPO/.git")
-	end)
-
-	after_each(function()
-		lib.luagit2_repository_free(repo)
-		fixer.set_back()
-	end)
-
-	teardown(function()
-		lib.luagit2_shutdown()
-	end)
-
-	--[[
+    local luagit2 = require("luagit2")
+    
+    setup(function()
+        luagit2.init()
+    end)
+    
+    before_each(function()
+        fixer.set_repo("new_test_repo")
+        repo = luagit2.repository_open("Fixtures/WORKON_REPO/.git")
+    end)
+    
+    after_each(function()
+        luagit2.repository_free(repo)
+        fixer.set_back()
+    end)
+    
+    teardown(function()
+        luagit2.shutdown()
+    end)
+    
+    --[[
+ 
 		A simple output of `git config -l` on Fixtures/new_test_repo
 		After th repo has been fixed for testing , that is user.email
 		and user.name have been set (see fixer.set_repo())
-
+		 
 		user.email=YOUR_DEFAULT_GIT_USER_EMAIL
 		user.name=YOUR_DEFAULT_GIT_USER_NAME
 		core.repositoryformatversion=0
@@ -50,46 +51,52 @@ describe(" Signature Methods Tests ", function()
 		url.git@github.com:.pushinsteadof=http://github.com/
 		user.name=TEST_USER
 		user.email=testusernoreply@github.com
-		
+ 
 	]]--
-
-	it("Tests signature_default method",function()
-		-- Get the Default signature for repository
-		local sign_default = lib.luagit2_signature_default(repo)
-		assert.are.equal("TEST_USER", lib.luagit2_get_signature_details(sign_default,1))
-		assert.are.equal("testusernoreply@github.com", lib.luagit2_get_signature_details(sign_default,2))
-		lib.luagit2_signature_free(sign_default)
-	end)
-
-	it("Tests signature from string method",function()
-		-- Create a sign from a complete signature string
-		-- as you see in a commit.
-		local sign_string = "Testing_user <something@example.com> 1461698487 +0200"
-		local sign_from_string_buffer = lib.luagit2_signature_from_buffer(sign_string)
-
-		assert.are.equal("Testing_user", lib.luagit2_get_signature_details(sign_from_string_buffer,1))
-		assert.are.equal("something@example.com", lib.luagit2_get_signature_details(sign_from_string_buffer,2))
-		-- free the signature
-		lib.luagit2_signature_free(sign_from_string_buffer)
-	end)
-
-	it("Tests signature now method",function()
-		local sign_now = lib.luagit2_signature_now("new_user","new_user@example.com")
-
-		assert.are.equal("new_user", lib.luagit2_get_signature_details(sign_now,1))
-		assert.are.equal("new_user@example.com", lib.luagit2_get_signature_details(sign_now,2))
-		-- free the signature
-		lib.luagit2_signature_free(sign_now)
-	end)
-
-	it("Tests signature dup method",function()
-		local sign_now = lib.luagit2_signature_now("new_user","new_user@example.com")
-		local sign_dup = lib.luagit2_signature_dup(sign_now)
-
-		assert.are.equal("new_user", lib.luagit2_get_signature_details(sign_dup,1))
-		assert.are.equal("new_user@example.com", lib.luagit2_get_signature_details(sign_dup,2))
-		-- free the signatures
-		lib.luagit2_signature_free(sign_now)
-		lib.luagit2_signature_free(sign_dup)
-	end)
+    
+    it("Tests signature_default method", function()
+        -- Get the Default signature for repository
+        local sign_default = luagit2.signature_default(repo)
+        local name, email = luagit2.get_signature_details(sign_default)
+        
+        assert.are.equal("TEST_USER", name)
+        assert.are.equal("testusernoreply@github.com", email)
+        luagit2.signature_free(sign_default)
+    end)
+    
+    it("Tests signature from string method", function()
+        -- Create a sign from a complete signature string
+        -- as you see in a commit.
+        local sign_string = "Testing_user <something@example.com> 1461698487 +0200"
+        local sign_from_string_buffer = luagit2.signature_from_buffer(sign_string)
+        
+        local name, email = luagit2.get_signature_details(sign_from_string_buffer)
+        
+        assert.are.equal("Testing_user", name)
+        assert.are.equal("something@example.com", email)
+        -- free the signature
+        luagit2.signature_free(sign_from_string_buffer)
+    end)
+    
+    it("Tests signature now method", function()
+        local sign_now = luagit2.signature_now("new_user", "new_user@example.com")
+        local name, email = luagit2.get_signature_details(sign_now)
+        
+        assert.are.equal("new_user", name)
+        assert.are.equal("new_user@example.com", email)
+        -- free the signature
+        luagit2.signature_free(sign_now)
+    end)
+    
+    it("Tests signature dup method", function()
+        local sign_now = luagit2.signature_now("new_user", "new_user@example.com")
+        local sign_dup = luagit2.signature_dup(sign_now)
+        local name, email = luagit2.get_signature_details(sign_dup)
+        
+        assert.are.equal("new_user", name)
+        assert.are.equal("new_user@example.com", email)
+        -- free the signatures
+        luagit2.signature_free(sign_now)
+        luagit2.signature_free(sign_dup)
+    end)
 end)

--- a/tests/tag/test_tag_spec.lua
+++ b/tests/tag/test_tag_spec.lua
@@ -3,35 +3,35 @@
 local fixer = require("Fixtures.fix_repo")
 
 describe(" Tag Methods Tests ", function()
-	local lib = require("luagit2")
-	local repo
-	local tag_str = "0c37a5391bbff43c37f0d0371823a5509eed5b1d"
-	local tag_oid, tag
-	local target_commit_id_str = "5b5b025afb0b4c913b4c338a42934a3863bf3644"
-	local current_directory_path = lfs.currentdir()
+    local luagit2 = require("luagit2")
+    local repo
+    local tag_str = "0c37a5391bbff43c37f0d0371823a5509eed5b1d"
+    local tag_oid, tag
+    local target_commit_id_str = "5b5b025afb0b4c913b4c338a42934a3863bf3644"
+    local current_directory_path = lfs.currentdir()
+    
+    setup(function()
+        luagit2.init()
+    end)
+    
+    before_each(function()
+        fixer.set_repo("new_test_repo")
+        repo = luagit2.repository_open("Fixtures/WORKON_REPO/.git")
+        tag_oid = luagit2.oid_fromstr(tag_str)
+        tag = luagit2.tag_lookup(repo, tag_oid)
+    end)
+    
+    after_each(function()
+        luagit2.tag_free(tag)
+        luagit2.repository_free(repo)
+        fixer.set_back()
+    end)
+    
+    teardown(function()
+        luagit2.shutdown()
+    end)
 
-	setup(function()
-		lib.luagit2_init()
-	end)
-
-	before_each(function()
-		fixer.set_repo("new_test_repo")
-		repo = lib.luagit2_repository_open("Fixtures/WORKON_REPO/.git")
-		tag_oid = lib.luagit2_oid_fromstr(tag_str)
-		tag = lib.luagit2_tag_lookup(repo,tag_oid)
-	end)
-
-	after_each(function()
-		lib.luagit2_tag_free(tag)
-		lib.luagit2_repository_free(repo)
-		fixer.set_back()
-	end)
-
-	teardown(function()
-		lib.luagit2_shutdown()
-	end)
-
-	--[[ Output of ` git show-ref --tags ` on Fixtures/new_test_repo
+    --[[ Output of ` git show-ref --tags ` on Fixtures/new_test_repo
 		 gives this output
 
 		 We have used these values for tests
@@ -74,113 +74,111 @@ describe(" Tag Methods Tests ", function()
 
 		...
 
-		--------------------------------------------------------------------------------
+		--------------------------------------------------------------------------------------------
 	]]--
 
-	it("Tests tag id",function()
-		-- Check for the tag id, it should 
-		-- match one used to create it
-		local tag_id = lib.luagit2_tag_id(tag)
-		local tag_id_str = lib.luagit2_oid_tostr(tag_id)
-		assert.are.equal(tag_str, tag_id_str)
-	end)
-
-	it("Tests tag message",function()
-		-- Checks the tag message value
-		local tag_message = lib.luagit2_tag_message(tag)
-		assert.are.equal("test tag message\n",tag_message)
-	end)
-
-	it("Tests tag name",function()
-		-- Checks the tag name value
-		local tag_name = lib.luagit2_tag_name(tag)
-		assert.are.equal("v1.0",tag_name)
-	end)
-
-	it("Tests Target related functions",function()
-		-- Get the target object
-		local target_obj = lib.luagit2_tag_target(tag)
-		local target_obj_id = lib.luagit2_object_id(target_obj)
-		local target_obj_id_str = lib.luagit2_oid_tostr(target_obj_id)
-
-		-- Check if the obj_id matches the commit id
-		-- it should point at
-		assert.are.equal(target_commit_id_str,target_obj_id_str)
-		-- Free the used object
-		lib.luagit2_object_free(target_obj)
-
-		-- Alternatively target's id can be retrieved
-		-- using :
-		local target_id = lib.luagit2_tag_target_id(tag)
-		local test_target_str = lib.luagit2_oid_tostr(target_id)
-		assert.are.equal(target_commit_id_str,test_target_str)
-
-		-- Check the object type, Must be commit
-		local target_obj_type = lib.luagit2_tag_target_type(tag)
-		local type_str = lib.luagit2_object_type2string(target_obj_type)
-		assert.are.equal("commit",type_str)
-	end)
-
-	it("Tests the tagger signature",function()
-		local tagger = lib.luagit2_tag_tagger(tag)
-		local user_name = lib.luagit2_get_signature_details(tagger,1)
-		local user_email = lib.luagit2_get_signature_details(tagger,2)
-		assert.are.equal("Scott Chacon", user_name)
-		assert.are.equal("schacon@gmail.com", user_email)
-	end)
-
-	it("Tests tag owner",function()
-		-- Get the owner repository
-		local owner_repo = lib.luagit2_tag_owner(tag)
-
-		-- Get the repo path for that owner repository
-		local owner_repo_path = lib.luagit2_repository_path(owner_repo)
-
-		-- Check with absolute path 
-		assert.are.equal(current_directory_path .. "/Fixtures/WORKON_REPO/.git/" , owner_repo_path)
-	end)
-
-	it("Tests Tag create",function()
-		-- Lets Create a new Tag for the same target
-		-- commit
-		--
-		-- Build up params to create a new tag
-		local commit_oid = lib.luagit2_oid_fromstr(target_commit_id_str)
-		local otype_commit = lib.luagit2_object_string2type("commit")
-		local target_commit_obj = lib.luagit2_object_lookup(repo,commit_oid,otype_commit)
-		local signature = lib.luagit2_signature_now("user_name","something@example.com")
-		local tag_message = "Testing_new_tag_create"
-		local tag_name = "new_tag"
-
-		-- Create a tag
-		local new_tag_id = lib.luagit2_tag_create(repo,tag_name,target_commit_obj,signature,tag_message,1)
-		assert.is_not_nil(new_tag_id)
-		-- Lookup for the tag in repo,
-		-- this ensures that the tag object
-		-- has been successfuly created and stored in odb
-		local new_tag = lib.luagit2_tag_lookup(repo,new_tag_id)
-		local new_tag_target_id = lib.luagit2_tag_target_id(new_tag)
-		-- Check that the target object is same
-		assert.are.equal(target_commit_id_str,lib.luagit2_oid_tostr(new_tag_target_id))
-		-- Check if tagger is same
-		local tagger = lib.luagit2_tag_tagger(new_tag)
-		local user_name = lib.luagit2_get_signature_details(tagger,1)
-		local user_email = lib.luagit2_get_signature_details(tagger,2)
-		assert.are.equal("user_name", user_name)
-		assert.are.equal("something@example.com", user_email)
-
-		-- Check if the tag message and name are same
-		local new_tag_message = lib.luagit2_tag_message(new_tag)
-		assert.are.equal(tag_message,new_tag_message)
-
-		local new_tag_name = lib.luagit2_tag_name(new_tag)
-		assert.are.equal(tag_name,new_tag_name)
-
-		-- Delete the tag from repository
-		lib.luagit2_tag_delete(repo,tag_name)
-
-		-- Free the used tag objects
-		lib.luagit2_tag_free(new_tag)
-	end)
-
+    it("Tests tag id", function()
+        -- Check for the tag id, it should
+        -- match one used to create it
+        local tag_id = luagit2.tag_id(tag)
+        local tag_id_str = luagit2.oid_tostr(tag_id)
+        assert.are.equal(tag_str, tag_id_str)
+    end)
+    
+    it("Tests tag message", function()
+        -- Checks the tag message value
+        local tag_message = luagit2.tag_message(tag)
+        assert.are.equal("test tag message\n", tag_message)
+    end)
+    
+    it("Tests tag name", function()
+        -- Checks the tag name value
+        local tag_name = luagit2.tag_name(tag)
+        assert.are.equal("v1.0", tag_name)
+    end)
+    
+    it("Tests Target related functions", function()
+        -- Get the target object
+        local target_obj = luagit2.tag_target(tag)
+        local target_obj_id = luagit2.object_id(target_obj)
+        local target_obj_id_str = luagit2.oid_tostr(target_obj_id)
+        
+        -- Check if the obj_id matches the commit id
+        -- it should point at
+        assert.are.equal(target_commit_id_str, target_obj_id_str)
+        -- Free the used object
+        luagit2.object_free(target_obj)
+        
+        -- Alternatively target's id can be retrieved
+        -- using :
+        local target_id = luagit2.tag_target_id(tag)
+        local test_target_str = luagit2.oid_tostr(target_id)
+        assert.are.equal(target_commit_id_str, test_target_str)
+        
+        -- Check the object type, Must be commit
+        local target_obj_type = luagit2.tag_target_type(tag)
+        local type_str = luagit2.object_type2string(target_obj_type)
+        assert.are.equal("commit", type_str)
+    end)
+    
+    it("Tests the tagger signature", function()
+        local tagger = luagit2.tag_tagger(tag)
+        local user_name, user_email = luagit2.get_signature_details(tagger)
+        assert.are.equal("Scott Chacon", user_name)
+        assert.are.equal("schacon@gmail.com", user_email)
+    end)
+    
+    it("Tests tag owner", function()
+        -- Get the owner repository
+        local owner_repo = luagit2.tag_owner(tag)
+        
+        -- Get the repo path for that owner repository
+        local owner_repo_path = luagit2.repository_path(owner_repo)
+        
+        -- Check with absolute path
+        assert.are.equal(current_directory_path .. "/Fixtures/WORKON_REPO/.git/", owner_repo_path)
+    end)
+    
+    it("Tests Tag create", function()
+        -- Lets Create a new Tag for the same target
+        -- commit
+        --
+        -- Build up params to create a new tag
+        local commit_oid = luagit2.oid_fromstr(target_commit_id_str)
+        local otype_commit = luagit2.object_string2type("commit")
+        local target_commit_obj = luagit2.object_lookup(repo, commit_oid, otype_commit)
+        local signature = luagit2.signature_now("user_name", "something@example.com")
+        local tag_message = "Testing_new_tag_create"
+        local tag_name = "new_tag"
+        
+        -- Create a tag
+        local new_tag_id = luagit2.tag_create(repo, tag_name, target_commit_obj, signature, tag_message, 1)
+        assert.is_not_nil(new_tag_id)
+        -- Lookup for the tag in repo,
+        -- this ensures that the tag object
+        -- has been successfuly created and stored in odb
+        local new_tag = luagit2.tag_lookup(repo, new_tag_id)
+        local new_tag_target_id = luagit2.tag_target_id(new_tag)
+        -- Check that the target object is same
+        assert.are.equal(target_commit_id_str, luagit2.oid_tostr(new_tag_target_id))
+        -- Check if tagger is same
+        local tagger = luagit2.tag_tagger(new_tag)
+        local user_name, user_email = luagit2.get_signature_details(tagger)
+        assert.are.equal("user_name", user_name)
+        assert.are.equal("something@example.com", user_email)
+        
+        -- Check if the tag message and name are same
+        local new_tag_message = luagit2.tag_message(new_tag)
+        assert.are.equal(tag_message, new_tag_message)
+        
+        local new_tag_name = luagit2.tag_name(new_tag)
+        assert.are.equal(tag_name, new_tag_name)
+        
+        -- Delete the tag from repository
+        luagit2.tag_delete(repo, tag_name)
+        
+        -- Free the used tag objects
+        luagit2.tag_free(new_tag)
+    end)
+    
 end)

--- a/tests/tree/test_tree_spec.lua
+++ b/tests/tree/test_tree_spec.lua
@@ -3,148 +3,146 @@
 local fixer = require("Fixtures.fix_repo")
 
 describe(" Tree Methods Tests ", function()
-	local lib = require("luagit2")
-	local repo_path = "Fixtures/WORKON_REPO"
-	local tree_oid_string = "619f9935957e010c419cb9d15621916ddfcc0b96"
-	local README_oid_string = "1385f264afb75a56a5bec74243be9b367ba4ca08"
-	local tree_oid, tree , README_oid
-	local current_directory_path = lfs.currentdir()
-
-	setup(function()
-		lib.luagit2_init()
-	end)
-
-	before_each(function()
-		fixer.set_repo("new_test_repo")
-		repo = lib.luagit2_repository_open(repo_path)
-		tree_oid = lib.luagit2_oid_fromstr(tree_oid_string)
-		README_oid = lib.luagit2_oid_fromstr(README_oid_string)
-		tree = lib.luagit2_tree_lookup(repo,tree_oid)
-	end)
-
-	after_each(function()
-		lib.luagit2_tree_free(tree)
-		lib.luagit2_repository_free(repo)
-		fixer.set_back()
-	end)
-
-	teardown(function()
-		lib.luagit2_shutdown()
-	end)
-
-	--[[ A simple output of `git cat-file -p HEAD^{tree}`
-		 on Fixtures/new_test_repo
-
-		100644 blob 1385f264afb75a56a5bec74243be9b367ba4ca08	README
-		100644 blob ce013625030ba8dba906f756967f9e9ca394464a	abc.txt
-		100644 blob fa49b077972391ad58037050f2a75f74e3671e92	new.txt
-		040000 tree 619f9935957e010c419cb9d15621916ddfcc0b96	subdir <--------|
-																				|
-		---------------------------------------------------------------         |
-																				|
-		An output of                                                            | 
-		-$ git ls-tree 619f9935957e010c419cb9d15621916ddfc  <-------------------|
-
-		100644 blob 1385f264afb75a56a5bec74243be9b367ba4ca08	README
-		100644 blob fa49b077972391ad58037050f2a75f74e3671e92	new.txt
-		040000 tree f60079018b664e4e79329a7ef9559c8d9e0378d1	subdir2
-	]]--
-
-	it("Tests Tree id",function()
-		-- It tests that id of tree generated
-		-- acually matches one used for creation
-
-		local tree_id_check = lib.luagit2_tree_id(tree)
-		local tree_id_str_check = lib.luagit2_oid_tostr_s(tree_id_check)
-		assert.are.equal(tree_oid_string,tree_id_str_check)
-
-	end)
-
-	it("Tests Tree owner repository",function()
-		local owner_repo = lib.luagit2_tree_owner(tree)
-		local owner_repo_path = lib.luagit2_repository_path(owner_repo)
-
-		-- Check with absolute path 
-		assert.are.equal(current_directory_path .. "/Fixtures/WORKON_REPO/.git/" , owner_repo_path)
-	end)
-
-	it("Tests tree lookup by prefix",function()
-		-- Lookup using first 5 chars of oid
-		local tree_by_prefix = lib.luagit2_tree_lookup_prefix(repo,tree_oid,5)
-
-		-- Check for returned oid value
-		-- Must match with original value
-		local tree_id_check = lib.luagit2_tree_id(tree_by_prefix)
-		local tree_id_str_check = lib.luagit2_oid_tostr_s(tree_id_check)
-		assert.are.equal(tree_oid_string,tree_id_str_check)
-	end)
-
-	it("Tests Tree entry count",function()
-		--
-		-- Get th entries count
-		-- It should be equal to '3'
-		-- As seen in the output of git ls-tree
-		--
-		local count = lib.luagit2_tree_entrycount(tree)
-		assert.are.equal(3,count)
-	end)
-
-	it("Tests getting Tree entries ",function()
-		--
-		-- Here we retrieve trww entries by different
-		-- available methods. Then we check for their
-		-- Values.
-		--
-		-- By oid of README
-		local README_entry_by_id = lib.luagit2_tree_entry_byid(tree,README_oid)
-
-		-- Since README is the first in tree, its index value is 0
-		local README_entry_byindex = lib.luagit2_tree_entry_byindex(tree,0)
-
-		-- Make sure this object does exist in tree by
-		-- given name. 
-		local README_entry_byname = lib.luagit2_tree_entry_byname(tree,"README")
-
-		-- README is in the current path pointed 
-		-- by tree object. Hence simply passing the name 
-		-- would work.
-		local README_entry_bypath = lib.luagit2_tree_entry_bypath(tree,"README")
-
-
-		-- Get ids for each tree entry
-		local entry_oid_byid = lib.luagit2_tree_entry_id(README_entry_by_id)
-		local entry_oid_byindex = lib.luagit2_tree_entry_id(README_entry_byindex)
-		local entry_oid_byname = lib.luagit2_tree_entry_id(README_entry_byname)
-		local entry_oid_bypath = lib.luagit2_tree_entry_id(README_entry_bypath)
-
-		-- Get the names for different Entries
-		local entry_name_byid = lib.luagit2_tree_entry_name(README_entry_by_id)
-		local entry_name_byindex = lib.luagit2_tree_entry_name(README_entry_by_id)
-		local entry_name_byname = lib.luagit2_tree_entry_name(README_entry_by_id)
-		local entry_name_bypath = lib.luagit2_tree_entry_name(README_entry_by_id)
-
-		-- Check for the values of oids
-		-- They all must be consistent with readme's oid string value
-		assert.are.equal(README_oid_string,lib.luagit2_oid_tostr_s(entry_oid_byid))
-		assert.are.equal(README_oid_string,lib.luagit2_oid_tostr_s(entry_oid_byindex))
-		assert.are.equal(README_oid_string,lib.luagit2_oid_tostr_s(entry_oid_byname))
-		assert.are.equal(README_oid_string,lib.luagit2_oid_tostr_s(entry_oid_bypath))
-
-		-- Check for the values of entry names 
-		-- They all must be README .
-		assert.are.equal("README",entry_name_byid)
-		assert.are.equal("README",entry_name_byindex)
-		assert.are.equal("README",entry_name_byname)
-		assert.are.equal("README",entry_name_bypath)
-
-	end)
-
-	it("Tests tree entry's object type",function()
-		local README_entry_by_id = lib.luagit2_tree_entry_byid(tree,README_oid)
-		local entry_type = lib.luagit2_tree_entry_type(README_entry_by_id)
-
-		local type_value = lib.luagit2_object_type2string(entry_type)
-		assert.are.equal("blob",type_value)
-	end)
-
+    local luagit2 = require("luagit2")
+    local repo_path = "Fixtures/WORKON_REPO"
+    local tree_oid_string = "619f9935957e010c419cb9d15621916ddfcc0b96"
+    local readme_oid_string = "1385f264afb75a56a5bec74243be9b367ba4ca08"
+    local tree_oid, tree, readme_oid
+    local current_directory_path = lfs.currentdir()
+    
+    setup(function()
+        luagit2.init()
+    end)
+    
+    before_each(function()
+        fixer.set_repo("new_test_repo")
+        repo = luagit2.repository_open(repo_path)
+        tree_oid = luagit2.oid_fromstr(tree_oid_string)
+        readme_oid = luagit2.oid_fromstr(readme_oid_string)
+        tree = luagit2.tree_lookup(repo, tree_oid)
+    end)
+    
+    after_each(function()
+        luagit2.tree_free(tree)
+        luagit2.repository_free(repo)
+        fixer.set_back()
+    end)
+    
+    teardown(function()
+        luagit2.shutdown()
+    end)
+    
+    --[[ A simple output of `git cat-file -p HEAD^{tree}`
+		on Fixtures/new_test_repo
+		 
+		100644 blob 1385f264afb75a56a5bec74243be9b367ba4ca08README
+		100644 blob ce013625030ba8dba906f756967f9e9ca394464aabc.txt
+		100644 blob fa49b077972391ad58037050f2a75f74e3671e92new.txt
+		040000 tree 619f9935957e010c419cb9d15621916ddfcc0b96subdir <--------|
+																			|
+		---------------------------------------------------------------     |
+																			|
+		An output of                                                        | 
+		-$ git ls-tree 619f9935957e010c419cb9d15621916ddfc  <---------------|
+		 
+		100644 blob 1385f264afb75a56a5bec74243be9b367ba4ca08README
+		100644 blob fa49b077972391ad58037050f2a75f74e3671e92new.txt
+		040000 tree f60079018b664e4e79329a7ef9559c8d9e0378d1subdir2
+		]]--
+    
+    it("Tests Tree id", function()
+        -- It tests that id of tree generated
+        -- acually matches one used for creation
+        
+        local tree_id_check = luagit2.tree_id(tree)
+        local tree_id_str_check = luagit2.oid_tostr_s(tree_id_check)
+        assert.are.equal(tree_oid_string, tree_id_str_check)
+        
+    end)
+    
+    it("Tests Tree owner repository", function()
+        local owner_repo = luagit2.tree_owner(tree)
+        local owner_repo_path = luagit2.repository_path(owner_repo)
+        
+        -- Check with absolute path
+        assert.are.equal(current_directory_path .. "/Fixtures/WORKON_REPO/.git/", owner_repo_path)
+    end)
+    
+    it("Tests tree lookup by prefix", function()
+        -- Lookup using first 5 chars of oid
+        local tree_by_prefix = luagit2.tree_lookup_prefix(repo, tree_oid, 5)
+        
+        -- Check for returned oid value
+        -- Must match with original value
+        local tree_id_check = luagit2.tree_id(tree_by_prefix)
+        local tree_id_str_check = luagit2.oid_tostr_s(tree_id_check)
+        assert.are.equal(tree_oid_string, tree_id_str_check)
+    end)
+    
+    it("Tests Tree entry count", function()
+        --
+        -- Get th entries count
+        -- It should be equal to '3'
+        -- As seen in the output of git ls-tree
+        --
+        local count = luagit2.tree_entrycount(tree)
+        assert.are.equal(3, count)
+    end)
+    
+    it("Tests getting Tree entries ", function()
+        --
+        -- Here we retrieve trww entries by different
+        -- available methods. Then we check for their
+        -- Values.
+        --
+        -- By oid of README
+        local readme_entry_by_id = luagit2.tree_entry_byid(tree, readme_oid)
+        
+        -- Since README is the first in tree, its index value is 0
+        local readme_entry_byindex = luagit2.tree_entry_byindex(tree, 0)
+        
+        -- Make sure this object does exist in tree by
+        -- given name.
+        local readme_entry_byname = luagit2.tree_entry_byname(tree, "README")
+        
+        -- README is in the current path pointed
+        -- by tree object. Hence simply passing the name
+        -- would work.
+        local readme_entry_bypath = luagit2.tree_entry_bypath(tree, "README")
+        
+        -- Get ids for each tree entry
+        local entry_oid_byid = luagit2.tree_entry_id(readme_entry_by_id)
+        local entry_oid_byindex = luagit2.tree_entry_id(readme_entry_byindex)
+        local entry_oid_byname = luagit2.tree_entry_id(readme_entry_byname)
+        local entry_oid_bypath = luagit2.tree_entry_id(readme_entry_bypath)
+        
+        -- Get the names for different Entries
+        local entry_name_byid = luagit2.tree_entry_name(readme_entry_by_id)
+        local entry_name_byindex = luagit2.tree_entry_name(readme_entry_by_id)
+        local entry_name_byname = luagit2.tree_entry_name(readme_entry_by_id)
+        local entry_name_bypath = luagit2.tree_entry_name(readme_entry_by_id)
+        
+        -- Check for the values of oids
+        -- They all must be consistent with readme's oid string value
+        assert.are.equal(readme_oid_string, luagit2.oid_tostr_s(entry_oid_byid))
+        assert.are.equal(readme_oid_string, luagit2.oid_tostr_s(entry_oid_byindex))
+        assert.are.equal(readme_oid_string, luagit2.oid_tostr_s(entry_oid_byname))
+        assert.are.equal(readme_oid_string, luagit2.oid_tostr_s(entry_oid_bypath))
+        
+        -- Check for the values of entry names
+        -- They all must be README .
+        assert.are.equal("README", entry_name_byid)
+        assert.are.equal("README", entry_name_byindex)
+        assert.are.equal("README", entry_name_byname)
+        assert.are.equal("README", entry_name_bypath) 
+    end)
+    
+    it("Tests tree entry's object type", function()
+        local readme_entry_by_id = luagit2.tree_entry_byid(tree, readme_oid)
+        local entry_type = luagit2.tree_entry_type(readme_entry_by_id)
+        
+        local type_value = luagit2.object_type2string(entry_type)
+        assert.are.equal("blob", type_value)
+    end)
+    
 end)


### PR DESCRIPTION
- I have modified the source code of  libgit, oid , tree, tag, signature  module to make usage of luagit2 easy and more close to lua way. 
- I also modified test for corresponding modules to match newly named function usage. I have tried to follow this style guide to rewrite tests (https://github.com/luarocks/lua-style-guide).


**Please run test for only libgit, oid , tree, tag, signature module on this branch as I have not changed tests of other modules to match new styling.**